### PR TITLE
feat(adr): ADR authoring guardrail + agent rule, and backfill 0010-0024

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -23,5 +23,9 @@ rules.
   code.
 - Before a PR run `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build`. Lint and
   format are biome. Tests are vitest. A behavior change needs a test.
+- An architecturally significant decision (one that constrains future work, is hard to
+  reverse, or would draw a later "why is it like this?") earns an ADR under `docs/adr/`.
+  The test and procedure are in ADR 0001: copy `0000-template.md`, fill it, add the index
+  row in `docs/adr/README.md`. `pnpm adr:check` gates structure and index sync in CI.
 - Write prose in the de-slop style. Avoid filler verbs and marketing adjectives, and do
   not open a clause with an em-dash.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,17 @@ jobs:
       - run: pnpm lint
       - run: pnpm typecheck
 
+  adr:
+    name: ADR guardrail
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      # Pure-node corpus check (no deps): structure, numbering, and README index sync.
+      - run: node scripts/check-adrs.mjs
+
   test:
     name: Test
     runs-on: macos-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,10 @@ Spec the unit, then add one plugin file plus one `BUILTIN_PLUGINS` line in `apps
 
 Adding a package manager is a one-file plus one-line change: a new `apps/cli/plugins/<id>.ts` and its registration. No edits to dispatch, help, completions, or conformance.
 
+## Decisions
+
+A choice that constrains future work, is hard to reverse, or would later make someone ask "why is it like this?" earns an ADR. That test and the procedure live in ADR 0001. Copy `docs/adr/0000-template.md` to the next number, fill Context, Decision, Alternatives, and Consequences, set the status and date, then add the index row in `docs/adr/README.md`. Run `pnpm adr:check`: it gates structure, sequential numbering, and index sync, and CI runs it on every push. It cannot tell when an ADR is missing, so that call is yours.
+
 ## Don't
 
 - Don't bypass `ExecRunner` (`apps/cli/src/exec/run.ts`) with direct `execa` or `child_process`. It carries dry-run, logging, and redaction, and the hermetic tests depend on it.

--- a/docs/adr/0010-execrunner-subprocess-seam.md
+++ b/docs/adr/0010-execrunner-subprocess-seam.md
@@ -1,0 +1,24 @@
+# ADR 0010: ExecRunner as the single subprocess seam
+
+> Status: accepted · Date: 2026-06-19 · Deciders: John Valai
+
+## Context
+
+Every backend macup drives is a subprocess: `brew`, `npm`, `pnpm`, `mas`, `softwareupdate`, `xcode-select`. If feature code called `execa` or `child_process` directly, process invocation would scatter across every plugin, each call site would couple to the process library, output handling would be reimplemented per plugin, and tests would have to spawn real binaries to exercise anything.
+
+## Decision
+
+Route all subprocess execution through an `ExecRunner` interface (`run`, `runJson`, `onPath`) defined in `apps/cli/src/plugins/types.ts`. The only module that imports `execa` is `apps/cli/src/exec/run.ts` (`ExecaExecRunner`). Cross-cutting behavior is layered as decorators selected by `buildExecRunner`: `StreamingExecRunner` routes output to the UI by `ExecRunKind`, and `TracingExecRunner` emits the `--debug` trace. Feature code receives the runner as `PluginContext.exec` and never imports a process library. CLAUDE.md states the rule directly: do not bypass `ExecRunner`.
+
+## Alternatives
+
+- Call `execa` directly in each plugin. Scatters invocation, recouples every call site to the library, and forces tests to spawn real package managers.
+- Mock `execa` at the module level in tests. Implicit, and it leaves production code with no seam for output routing or tracing.
+- Adopt a heavier process-orchestration dependency. The value is the seam, not the library. `execa` already covers the need behind the interface.
+
+## Consequences
+
+- One place to add behavior that must apply to every command: UI output routing and `--debug` tracing already attach here, and output redaction or throttling would attach the same way.
+- Tests inject a `FixtureExecRunner` (ADR 0012) against the same interface, so units run with no live subprocess.
+- The cost is one layer of indirection and the standing rule that feature code takes `ctx.exec`, enforced in review.
+- Dry-run is not the runner's concern: each plugin checks `opts.dryRun` and skips the mutating call before it reaches the seam.

--- a/docs/adr/0011-errpluginunavailable-contract.md
+++ b/docs/adr/0011-errpluginunavailable-contract.md
@@ -1,0 +1,24 @@
+# ADR 0011: ErrPluginUnavailable as the plugin availability contract
+
+> Status: accepted · Date: 2026-06-19 · Deciders: John Valai
+
+## Context
+
+macup aggregates several package managers, and on any given machine some are absent or unusable: Homebrew may not be installed, `mas` may not be signed in, a manager may not support the host OS. A plugin's `check()` needs to signal "I cannot run here" in a way the caller can tell apart from an unexpected crash, so that `macup all` can skip a missing backend while a direct `macup brew` invocation reports the reason cleanly.
+
+## Decision
+
+`check()` throws `ErrPluginUnavailable(pluginId, reason)`, a typed error in `apps/cli/src/errors.ts` that extends `MacupError` with `kind: 'plugin-unavailable'` and carries the plugin id and a human reason. It is not a bare `Error`. The composite `all` plugin runs each constituent's `check()` inside a try/catch and continues on failure, logging `[id] skipped: <reason>`, so one unavailable backend does not abort the run. CLAUDE.md records the rule: plugins throw `ErrPluginUnavailable` from `check()`, not a bare `Error`.
+
+## Alternatives
+
+- Throw a bare `Error` and match on its message. Fragile: message strings drift, and nothing distinguishes "not available" from "broke unexpectedly".
+- Return a result object such as `{ ok: false, reason }` from `check()`. Loses the throw that the single-plugin path wants for a clean nonzero exit, and splits availability into two shapes.
+- Probe availability in the registry instead of in `check()`. Duplicates the per-plugin probing the plugin already owns (`onPath`, sign-in checks).
+
+## Consequences
+
+- The composite stays resilient: a missing or unconfigured backend becomes a skip with a readable reason, not a failed run.
+- A direct single-plugin invocation can map the typed error to a clean message and the `MacupError` exit code.
+- Every plugin's `check()` must throw the typed error, which review enforces.
+- The composite's catch is broad: it catches any error, not only `ErrPluginUnavailable`, so a genuine bug inside a constituent is also swallowed as a skip. That is a deliberate trade in favor of finishing the run over surfacing one backend's crash. `--debug` still traces it.

--- a/docs/adr/0012-hermetic-deterministic-testing.md
+++ b/docs/adr/0012-hermetic-deterministic-testing.md
@@ -1,0 +1,25 @@
+# ADR 0012: Hermetic, deterministic testing via injected fakes
+
+> Status: accepted · Date: 2026-06-19 · Deciders: John Valai
+
+## Context
+
+Tests must not call real `brew`, `mas`, or `npm`, hit the network, touch `$HOME`, or depend on the developer's machine, locale, or terminal (docs/TESTING_STRATEGY.md, section 2). Two things make a CLI like this flaky if tested naively: spawning real package managers, and asserting against a live terminal whose bytes depend on the emulator.
+
+## Decision
+
+Test against the seams rather than the world. For subprocesses, inject a `FixtureExecRunner` (`apps/cli/src/exec/fixtures.ts`) that replays recorded `(cmd, args, result)` tuples from JSON recordings under `test/fixtures/recordings/` and throws a loud `Fixture miss` on any unmatched call. For terminal output, drive the real `StatusBar` into a minimal headless VT screen buffer (`apps/cli/test/visual/vt-screen.ts`) that applies the escape subset the UI emits to a fixed cell grid and snapshots the rendered plain text. No live subprocess, no live TTY, no network. The full layering and conventions live in docs/TESTING_STRATEGY.md. This ADR records the choice, not the how-to.
+
+## Alternatives
+
+- Spawn the real package managers. Slow, non-deterministic, and dependent on machine state and network. Reserved only for the (currently empty) e2e layer.
+- Mock `execa` with `vi.mock` at the module level. Implicit and per-test. The injected `ExecRunner` (ADR 0010) is explicit and reused across units and integration.
+- Snapshot the raw ANSI byte stream. Couples assertions to exact escape sequences instead of the rendered result, and breaks under harmless reordering.
+- Adopt `@xterm/headless` for the VT model. Heavier than the escape subset the `StatusBar` actually emits. Kept as the documented fallback if the CLI outgrows the minimal buffer.
+
+## Consequences
+
+- Tests are fast and reproducible: CI matches local, with no flake from clock, locale, TTY, color, or network.
+- A `Fixture miss` turns a mis-wired call into an immediate, named failure instead of a silent real subprocess.
+- The cost is upkeep: a recording per command path, and a new escape the UI emits must be added to the VT buffer (or the model swapped for `@xterm/headless`).
+- This is the reason ADR 0010's `ExecRunner` seam has the shape it does: one interface backs both production and the fixture fake.

--- a/docs/adr/0013-biome-lint-format.md
+++ b/docs/adr/0013-biome-lint-format.md
@@ -1,0 +1,23 @@
+# ADR 0013: biome for lint and format
+
+> Status: accepted · Date: 2026-06-19 · Deciders: John Valai
+
+## Context
+
+The project needs linting and formatting. The conventional choice is ESLint plus Prettier: two tools, two configs, and a plugin chain to keep in sync. ADR 0002 rejected adopting the playbook's default stack wholesale, which left the individual tool picks open.
+
+## Decision
+
+Use biome for both lint and format. Configuration is a single `biome.json` at the repo root. `pnpm lint` runs `biome check .` and `pnpm format` runs `biome format --write .`. One tool, one config, covering the monorepo with explicit ignores for `dist`, `node_modules`, the lockfile, `.worktrees`, and the docs app.
+
+## Alternatives
+
+- ESLint plus Prettier. Two tools to configure and keep from fighting each other, a slower pass, and ongoing plugin churn.
+- ESLint alone. No formatter, so style still needs a second tool.
+- dprint or Deno fmt. Formatting only. A separate linter would still be required.
+
+## Consequences
+
+- A single, fast pass in CI and locally, with one config to reason about.
+- biome's rule set is narrower than ESLint's plugin ecosystem, so a check that only an ESLint plugin offers is not available. That is the accepted trade for the simpler toolchain.
+- Prose quality is out of scope here and handled by the de-slop gate (ADR 0017).

--- a/docs/adr/0014-vitest-test-runner.md
+++ b/docs/adr/0014-vitest-test-runner.md
@@ -1,0 +1,23 @@
+# ADR 0014: vitest as the test runner
+
+> Status: accepted · Date: 2026-06-19 · Deciders: John Valai
+
+## Context
+
+The codebase is TypeScript and ESM (ADR 0020), and the test strategy (ADR 0012) leans on injected fakes and snapshots. The runner has to handle native ESM and TypeScript without a transpile-to-CommonJS step, and support snapshot assertions for the VT screen tests.
+
+## Decision
+
+Use vitest. Each package configures it (`apps/cli/vitest.config.ts`), `test` runs `vitest run`, and the root `pnpm test` fans out through Turborepo (ADR 0009). Watch mode is `pnpm --filter macup test:watch`.
+
+## Alternatives
+
+- Jest. Rooted in CommonJS. ESM support needs config gymnastics and a TypeScript transform, against the grain of an ESM-native codebase.
+- Mocha with chai and ts-node. More assembly: runner, assertion library, and a TypeScript loader wired by hand.
+- Node's built-in `node:test`. Younger ecosystem for mocking and snapshots. The fixture and VT-snapshot patterns lean on vitest's ergonomics.
+
+## Consequences
+
+- Native ESM and TypeScript, fast watch, and snapshot support that the VT rendering tests (ADR 0012) depend on.
+- The suite is tied to vitest's API and config shape. Moving runners would touch every test file.
+- Root test orchestration goes through Turborepo, so caching and `--filter` apply to tests as to any other task.

--- a/docs/adr/0015-tsup-npm-bundle.md
+++ b/docs/adr/0015-tsup-npm-bundle.md
@@ -1,0 +1,23 @@
+# ADR 0015: tsup for the npm bundle
+
+> Status: accepted · Date: 2026-06-19 · Deciders: John Valai
+
+## Context
+
+macup ships to npm as an ESM entry point (`apps/cli/dist/cli.mjs`) plus a typed `meta` export. This is a separate artifact from the standalone single binary in ADR 0007 (`bun build --compile`), and a separate build decision: the npm path needs bundling, a `.mjs` extension, type declarations for the public `meta` export, and an executable bit.
+
+## Decision
+
+Use tsup (`apps/cli/tsup.config.ts`): entries `src/cli.ts` and `src/meta.ts`, ESM-only output, `target: node20`, `.mjs` extension, `dts` for the `meta` entry, sourcemaps on, and `chmod +x dist/cli.mjs` on success. `pnpm build` runs `tsup`.
+
+## Alternatives
+
+- Raw esbuild. tsup wraps it. Using esbuild directly would mean hand-wiring multiple entries, declaration output, and the post-build chmod that tsup gives for free.
+- `tsc` emit only. No bundling or tree-shaking, and it ships a tree of files rather than one entry.
+- webpack or rollup. Heavier configuration than a single-package CLI needs.
+
+## Consequences
+
+- A near-zero-config ESM bundle with declarations for the `meta` export, built in one command.
+- Two build paths now exist, tsup for npm and bun `--compile` for the binary (ADR 0007). The ADRs keep them distinct so the two are not confused.
+- tsup is an esbuild wrapper, so esbuild's limits (for example, no type-checking during bundling, which `pnpm typecheck` covers separately) apply.

--- a/docs/adr/0016-conventional-commits-ci-gate.md
+++ b/docs/adr/0016-conventional-commits-ci-gate.md
@@ -1,0 +1,24 @@
+# ADR 0016: Conventional Commits enforced in CI
+
+> Status: accepted · Date: 2026-06-19 · Deciders: John Valai
+
+## Context
+
+macup wants history that reads cleanly and stays parseable for changelog and version tooling. Without a gate, commit subjects drift in format. The repo also keeps all three GitHub merge methods (merge, squash, rebase), so any commit-level gate has to tolerate merge commits rather than reject them.
+
+## Decision
+
+Enforce Conventional Commits on every non-merge commit subject in a pull request with a self-contained bash check in `.github/workflows/commits.yml`: no external action, no config file, just a pattern allowing `feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert` with an optional scope and `!`. Subjects starting with `Merge` are skipped. A second workflow, `.github/workflows/pr-title.yml` (amannn/action-semantic-pull-request), keeps the PR title in the same shape for readable PR lists and squash-merge subjects.
+
+## Alternatives
+
+- No gate. Format drifts and depends on each contributor's discipline.
+- commitlint plus a husky hook. Adds a dependency and config for what a one-line grep pattern already does.
+- Gate the PR title only. Does not constrain the commits that actually land under merge or rebase.
+
+## Consequences
+
+- Landed history is machine-parseable, which keeps changelog and semantic-version inference on the table.
+- `commits.yml` is the enforcing gate on history. `pr-title.yml` is title hygiene.
+- Skipping merge subjects is exactly what lets all three merge methods stay enabled.
+- Contributors must shape subjects to the pattern. Prose quality inside bodies and docs is a separate concern, covered by the de-slop gate (ADR 0017).

--- a/docs/adr/0017-deslop-prose-gate.md
+++ b/docs/adr/0017-deslop-prose-gate.md
@@ -1,0 +1,25 @@
+# ADR 0017: De-slop prose gate
+
+> Status: accepted · Date: 2026-06-19 · Deciders: John Valai
+
+## Context
+
+macup generates a lot of prose: docs, ADRs, READMEs, and commit bodies. The project follows a written-style guide from its engineering playbook and wants that prose kept free of generated-text tells and typographic drift, without a human having to police every diff.
+
+## Decision
+
+Run deslopper (github.com/jv-k/deslopper, pinned to a specific commit) over changed Markdown, both as a CI gate (`.github/workflows/writing-style.yml`) and as a local pre-commit hook (simple-git-hooks). Error-tier tells, such as em dashes and the section sign, fail the build. Warn-tier findings, such as the filler word lists and bold bullet leads, annotate the PR but do not block. Only files changed in the PR are linted, so the legacy prose backlog does not fail the check.
+
+## Alternatives
+
+- No gate. Prose decays and the banned typography creeps back in over time.
+- A general style checker such as Vale. Heavier to configure, and deslopper already encodes this project's specific tells.
+- Block on every finding. Would fail on acceptable variation and make the gate adversarial.
+- Review by eye only. Not enforced, and easy to skip under time pressure.
+
+## Consequences
+
+- User-facing prose and these ADRs stay in the house style, checked automatically.
+- Linting only changed files means old docs are not retroactively failed. The backlog is paid down as files are touched.
+- The pinned commit makes the rule set reproducible. Tightening it is a deliberate version bump.
+- The local hook fetches deslopper over the network via uvx, so an offline commit has to skip the hook and rely on the CI gate. That is an accepted operational wrinkle, not a hole: CI still blocks the merge.

--- a/docs/adr/0018-release-and-distribution.md
+++ b/docs/adr/0018-release-and-distribution.md
@@ -1,0 +1,26 @@
+# ADR 0018: Release through npm with provenance and a Homebrew tap
+
+> Status: accepted · Date: 2026-06-19 · Deciders: John Valai
+
+## Context
+
+macup needs to reach two audiences: Node developers who install from npm, and macOS users who prefer a native install. It also wants a verifiable supply chain for the npm package and reproducible binaries for the tap. ADR 0007 already chose `bun build --compile` for the binary artifact. This decision is about the distribution channels and the pipeline that ships them.
+
+## Decision
+
+One release workflow (`.github/workflows/release.yml`), triggered by a published GitHub Release or manual dispatch, publishes to both channels. It re-verifies at the tagged ref (lint, typecheck, test, build), publishes to npm with `--provenance` (`id-token: write`, plus a check that `package.json` version matches the tag), builds darwin arm64 and x64 binaries with SHA256 checksums and uploads them to the GitHub Release, then fires a `repository_dispatch` to the separate Homebrew tap repository (`scripts/update-homebrew-tap.ts`) carrying the tag and checksums. Every job is gated on `vars.RELEASE_ENABLED == 'true'`, so the workflow is reviewable in pull requests while staying inert until launch.
+
+## Alternatives
+
+- npm only. Misses macOS users who expect `brew install`.
+- Homebrew only. Excludes the npm audience and Node-based installs.
+- Publish without provenance. A weaker supply-chain story now that attestation is automatic for GitHub Actions.
+- Commit the tap Formula from this repo. Would require the tap's write credentials here. The dispatch keeps them in the tap repository instead.
+
+## Consequences
+
+- Two install paths from a single tagged release.
+- npm provenance gives consumers an attested build origin.
+- The tap repository regenerates its Formula from the dispatched tag and checksums, so this repo holds no tap credentials.
+- The pipeline stays dormant behind `RELEASE_ENABLED` until the first public release, so the file lands and is reviewed without risk of an accidental publish.
+- The binaries are darwin-only, consistent with ADR 0008.

--- a/docs/adr/0019-pinned-playwright-visual-snapshots.md
+++ b/docs/adr/0019-pinned-playwright-visual-snapshots.md
@@ -1,0 +1,24 @@
+# ADR 0019: Pinned Playwright container for docs visual snapshots
+
+> Status: accepted · Date: 2026-06-19 · Deciders: John Valai
+
+## Context
+
+The docs site (`apps/docs`) has visual snapshot tests that compare rendered screenshots against committed baselines. Screenshot pixels depend on font rasterization, which differs between machines and shifts whenever a CI runner image rolls. Baselines captured in one environment then produce false diffs in another, which a bare runner cannot prevent because its font stack moves with the image.
+
+## Decision
+
+Run the docs visual tests inside a pinned Playwright image, `mcr.microsoft.com/playwright:v1.61.0-noble`, in the `docs-visual` CI job, and commit `-linux` baselines generated in that same image. The Playwright config (`apps/docs/playwright.config.ts`) fixes everything that affects pixels: Desktop Chrome, a 1280x800 viewport, `deviceScaleFactor: 1`, disabled animations, and a small `maxDiffPixelRatio` of 0.01 to tolerate sub-pixel antialiasing while still catching a real visual change.
+
+## Alternatives
+
+- Run on a bare macOS or ubuntu runner. The font stack rolls with the runner image, so baselines drift and diffs go false.
+- Regenerate baselines on every run. Removes drift but also removes all regression detection.
+- Mask every piece of dynamic content. Weakens coverage to the point the test proves little.
+- Track the rolling `:latest` Playwright tag. Reintroduces drift each time the upstream image updates.
+
+## Consequences
+
+- Pixels are deterministic, so a failing snapshot means a real visual change, not environment noise.
+- Baselines are tied to this exact image, so bumping Playwright is a deliberate step that regenerates baselines in the new image.
+- This job runs on ubuntu inside the container rather than the macOS runners the rest of CI uses, because the committed baselines are `-linux`.

--- a/docs/adr/0020-node20-es2022-baseline.md
+++ b/docs/adr/0020-node20-es2022-baseline.md
@@ -1,0 +1,23 @@
+# ADR 0020: Node 20 and ES2022 as the baseline
+
+> Status: accepted · Date: 2026-06-19 · Deciders: John Valai
+
+## Context
+
+A CLI has to fix a runtime floor and a language target. That choice decides which syntax and built-ins are usable without polyfills, and which Node versions a user must have installed.
+
+## Decision
+
+Require Node >= 20 (`engines` in `apps/cli/package.json`), compile to `target: es2022` with `module: esnext` and `moduleResolution: bundler` (`tsconfig.base.json`), and build with tsup `target: node20`. Output is ESM only. There is no CommonJS build.
+
+## Alternatives
+
+- Node 18 as the floor. An older LTS with more conservative APIs, and it complicates top-level await and newer built-ins.
+- Chase Node 22+ as the floor. Excludes users on the then-current LTS for little gain.
+- Dual CommonJS and ESM output. Doubles the build and testing surface for a CLI that controls its own entry point.
+
+## Consequences
+
+- Top-level await, modern class fields, and current standard-library APIs are available without polyfills or down-leveling.
+- Users below Node 20 are unsupported. That is acceptable because the tool targets developer machines where Node 20+ is normal.
+- The floor is asserted in three places (`engines`, the CI runner, and the tsup target), so raising it is a coordinated edit rather than a silent drift.

--- a/docs/adr/0021-config-path-resolution.md
+++ b/docs/adr/0021-config-path-resolution.md
@@ -1,0 +1,23 @@
+# ADR 0021: Config path resolution with XDG and legacy migration
+
+> Status: accepted · Date: 2026-06-19 · Deciders: John Valai
+
+## Context
+
+The `applist.yaml` config has to be findable across setups: power users and CI that override the location, the XDG convention, a sensible default in the home directory, and users migrating from the predecessor tool `macos-updatetool`.
+
+## Decision
+
+`resolveConfigPaths` (`apps/cli/src/config/paths.ts`) resolves in a fixed order: `$MACUP_CONFIG`, then `$MACOS_UPDATETOOL_CONFIG` (deprecated, with a warning), then `$XDG_CONFIG_HOME/macup/applist.yaml` or `~/.config/macup/applist.yaml`. If neither of those exists but the legacy `~/.config/macos-updatetool/applist.yaml` does, it resolves there and offers migration to the new path. Backups live in `<configDir>/backups`. The function is pure (it takes `env`, `home`, and an `exists` probe), so it is unit-testable without touching the real filesystem.
+
+## Alternatives
+
+- A single fixed path. No override for CI or containers, and it ignores the XDG convention.
+- XDG only, no legacy handling. Strands users coming from `macos-updatetool`.
+- Read the legacy path with no migration offer. Leaves users split across two locations indefinitely.
+
+## Consequences
+
+- Overrides, XDG, and the home default all work, and legacy users get a deprecation warning plus a migration path rather than silent breakage.
+- Purity keeps the resolver hermetically testable, in line with ADR 0012.
+- The precedence is fixed in code, so adding a new source means inserting it deliberately into the chain.

--- a/docs/adr/0022-durable-comment-preserving-config-writes.md
+++ b/docs/adr/0022-durable-comment-preserving-config-writes.md
@@ -1,0 +1,24 @@
+# ADR 0022: Durable, comment-preserving config writes
+
+> Status: accepted · Date: 2026-06-19 · Deciders: John Valai
+
+## Context
+
+macup edits a user-owned YAML file that people hand-edit and commit to their dotfiles. Two risks follow: a crash mid-write could corrupt the file, and a naive round-trip could strip the user's comments and formatting on every change.
+
+## Decision
+
+Write atomically: serialize to `<path>.tmp`, then POSIX `rename` over the original (`atomicWriteFile` in `apps/cli/src/config/store.ts`), so a crash leaves the original intact. Parse with the `yaml` library's `parseDocument` (the CST) and mutate in place through `YAMLMap`, `YAMLSeq`, and `Scalar`, serializing with `doc.toString()` so comments and untouched formatting survive. Back the file up before a mutation, and compare against a normalized `doc.toString()` baseline so a cosmetic reflow does not trigger a spurious backup.
+
+## Alternatives
+
+- In-place truncate and write. Corruptible if the process dies mid-write.
+- Parse to a plain JS object and re-serialize. Drops comments and produces noisy diffs on every save.
+- Regex or string surgery on the YAML text. Fragile and unmaintainable as the schema grows.
+
+## Consequences
+
+- The config on disk is always fully old or fully new, never half-written.
+- User comments and layout are preserved across edits, so the file stays pleasant to hand-maintain.
+- Mutations must go through the CST API rather than a plain object tree, which is more verbose but keeps the round-trip honest.
+- The normalized-baseline comparison avoids backup churn when a save changes nothing meaningful.

--- a/docs/adr/0023-semver-first-version-comparison.md
+++ b/docs/adr/0023-semver-first-version-comparison.md
@@ -1,0 +1,23 @@
+# ADR 0023: Semver-first version comparison with a permissive fallback
+
+> Status: accepted · Date: 2026-06-19 · Deciders: John Valai
+
+## Context
+
+macup compares installed versus latest versions and enforces user pins, but its backends version differently: `npm` and `pnpm` use semver, while Homebrew (date-style versions) and `mas` (build IDs) do not. User-provided pins can also be malformed.
+
+## Decision
+
+The default comparator (`semverCompare` in `apps/cli/src/plugins/selection.ts`) tries semver: if both sides are valid semver it compares them, otherwise it returns equal. Equal-on-unknown is deliberate, so a non-semver or malformed pin neither crashes the run nor traps the user out of upgrades. Plugins whose versions are not semver supply their own `manifest.compareVersions`.
+
+## Alternatives
+
+- Strict semver only. Forces every non-semver plugin to implement a comparator, or crashes on Homebrew and `mas` versions.
+- Lexicographic string comparison as the default. Wrong for cases like `1.9` versus `1.10`.
+- Throw on non-semver input. A bad pin format should not abort the whole update.
+
+## Consequences
+
+- The common semver case works with no per-plugin code, and non-semver backends opt into correctness through `compareVersions`.
+- The permissive fallback means a malformed pin is silently treated as non-blocking rather than reported, the chosen trade in favor of finishing the update.
+- Version logic lives in `selection.ts`, separate from the config schema (ADR 0004).

--- a/docs/adr/0024-sandcastle-agent-orchestration.md
+++ b/docs/adr/0024-sandcastle-agent-orchestration.md
@@ -1,0 +1,24 @@
+# ADR 0024: Sandcastle for multi-agent implementation
+
+> Status: accepted · Date: 2026-06-19 · Deciders: John Valai
+
+## Context
+
+Much of macup is built by coding agents. The goal was to run several issues in parallel without a human approving each step, while protecting the host working tree from concurrent agent edits.
+
+## Decision
+
+Orchestrate with `@ai-hero/sandcastle` (`.sandcastle/main.mts`, run via `pnpm sandcastle`) in a Plan, Implement-times-N, Merge loop. A planner agent reads `status:ready-for-agent` issues and refuses any whose touched files overlap the host's dirty paths. Up to `MAX_PARALLEL` implementer agents then run in isolated Docker sandboxes on `sandcastle/issue-<n>-<slug>` branches, each followed by a reviewer that may refine the diff and opens the PR. A merger agent integrates the branches that produced commits back into `develop`, verifying lint, typecheck, and tests. `node_modules` is not copied into the Linux sandbox (the host is darwin/arm64), so each sandbox runs a fresh install.
+
+## Alternatives
+
+- A single agent working serially. Slower, with no parallelism across issues.
+- Agents editing the host checkout directly. Risks colliding with uncommitted work, the `SyncError` mode the planner's dirty-path guard exists to prevent.
+- A bespoke orchestrator. More to build and maintain than adopting the reference setup.
+
+## Consequences
+
+- Multiple issues progress per iteration, each in its own sandbox and branch.
+- The dirty-path guard keeps agent runs from clobbering uncommitted host edits.
+- This is opt-in tooling run on demand, not wired into CI.
+- The agent model is pinned in `main.mts`, so a model upgrade is a deliberate edit.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -8,9 +8,10 @@ the code.
 
 The rule for recording decisions is ADR 0001. A decision earns an ADR when it constrains future
 work, is hard to reverse, or is the kind of thing a new contributor would otherwise have to ask
-"why is it like this?". ADRs 0003 through 0008 backfill decisions that were already implicit in
-docs/PRD.md and the code; 0009 records the Phase 2 monorepo conversion. Where the original rationale was never written down, the ADR says so and
-marks the point open rather than inventing a reason.
+"why is it like this?". ADRs 0003 through 0008 and 0010 through 0024 backfill decisions that were
+already implicit in docs/PRD.md and the code; 0009 records the Phase 2 monorepo conversion. Where
+the original rationale was never written down, the ADR says so and marks the point open rather than
+inventing a reason.
 
 ## How to add one
 
@@ -36,3 +37,18 @@ ADR-NNNN". Do not rewrite the old record. The trail is the point.
 | [0007](0007-bun-compile-single-binary.md) | bun build --compile for single-binary distribution | accepted |
 | [0008](0008-darwin-only-scope.md) | darwin-only scope | accepted |
 | [0009](0009-monorepo-structure.md) | pnpm + Turborepo monorepo, CLI under apps/cli | accepted |
+| [0010](0010-execrunner-subprocess-seam.md) | ExecRunner as the single subprocess seam | accepted |
+| [0011](0011-errpluginunavailable-contract.md) | ErrPluginUnavailable as the plugin availability contract | accepted |
+| [0012](0012-hermetic-deterministic-testing.md) | Hermetic, deterministic testing via injected fakes | accepted |
+| [0013](0013-biome-lint-format.md) | biome for lint and format | accepted |
+| [0014](0014-vitest-test-runner.md) | vitest as the test runner | accepted |
+| [0015](0015-tsup-npm-bundle.md) | tsup for the npm bundle | accepted |
+| [0016](0016-conventional-commits-ci-gate.md) | Conventional Commits enforced in CI | accepted |
+| [0017](0017-deslop-prose-gate.md) | De-slop prose gate | accepted |
+| [0018](0018-release-and-distribution.md) | Release through npm with provenance and a Homebrew tap | accepted |
+| [0019](0019-pinned-playwright-visual-snapshots.md) | Pinned Playwright container for docs visual snapshots | accepted |
+| [0020](0020-node20-es2022-baseline.md) | Node 20 and ES2022 as the baseline | accepted |
+| [0021](0021-config-path-resolution.md) | Config path resolution with XDG and legacy migration | accepted |
+| [0022](0022-durable-comment-preserving-config-writes.md) | Durable, comment-preserving config writes | accepted |
+| [0023](0023-semver-first-version-comparison.md) | Semver-first version comparison with a permissive fallback | accepted |
+| [0024](0024-sandcastle-agent-orchestration.md) | Sandcastle for multi-agent implementation | accepted |

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "lint": "biome check .",
     "lint:fix": "biome check --write .",
     "format": "biome format --write .",
+    "adr:check": "node scripts/check-adrs.mjs",
     "shellcheck": "git ls-files '*.sh' | xargs shellcheck --severity=warning",
     "deslop:lint": "uvx --from git+https://github.com/jv-k/deslopper@ef16c9dc43f0e888dc15354522ee08fe795c917a deslopper lint",
     "sandcastle": "npx tsx .sandcastle/main.mts",

--- a/scripts/check-adrs.mjs
+++ b/scripts/check-adrs.mjs
@@ -30,7 +30,8 @@ const fail = (file, msg) => errors.push(`${file}: ${msg}`);
 
 const read = (file) => readFileSync(join(ADR_DIR, file), 'utf8');
 
-// Parse one ADR file. Records errors and returns its facts (or null when unparseable).
+// Parse one ADR file. Records errors via fail() and always returns a facts
+// object; fields it could not parse are null.
 function parseAdr(file) {
   const num = file.slice(0, 4);
   const lines = read(file).split('\n');
@@ -52,7 +53,7 @@ function parseAdr(file) {
       "missing status line (expected '> Status: <status> · Date: <date> · Deciders: <names>')",
     );
   } else {
-    const m = statusLine.match(/^> Status:\s*(.+?)\s*·\s*Date:\s*(.+?)\s*(?:·.*)?$/);
+    const m = statusLine.match(/^> Status:\s*(.+?)\s*·\s*Date:\s*(.+?)\s*·\s*Deciders:\s*\S.*$/);
     if (!m) {
       fail(file, "status line must be '> Status: <status> · Date: <date> · Deciders: <names>'");
     } else {
@@ -120,6 +121,9 @@ for (const line of indexLines) {
     continue;
   }
   const [, num, link, title, statusCell] = m;
+  if (rows.has(num)) {
+    fail(INDEX, `index lists ADR ${num} more than once`);
+  }
   rows.set(num, { link, title: title.trim(), status: statusCell.trim() });
   if (!entries.includes(link)) {
     fail(INDEX, `index row ${num} links to '${link}', which does not exist`);

--- a/scripts/check-adrs.mjs
+++ b/scripts/check-adrs.mjs
@@ -1,0 +1,161 @@
+#!/usr/bin/env node
+// Guardrail for docs/adr/. Validates that the ADR corpus is well-formed and the
+// README index is in sync. Run via `pnpm adr:check`; exits non-zero on any error.
+//
+// What it enforces:
+//   - filenames are NNNN-kebab-title.md
+//   - decision ADRs are numbered contiguously from 0001 (no gaps, no duplicates)
+//   - each ADR has a matching H1, a Status/Date line, and the four template sections
+//   - status is proposed | accepted | superseded by ADR-NNNN, and a superseding target exists
+//   - the README index lists every decision ADR once, links resolve, and title + status match
+//
+// What it cannot do: decide whether a code change SHOULD have produced a new ADR.
+// That judgment stays with the author and reviewer (see ADR 0001). This check only
+// keeps the corpus and the index honest once an ADR is written.
+
+import { readFileSync, readdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ADR_DIR = join(dirname(fileURLToPath(import.meta.url)), '..', 'docs', 'adr');
+const TEMPLATE = '0000-template.md';
+const INDEX = 'README.md';
+const REQUIRED_SECTIONS = ['Context', 'Decision', 'Alternatives', 'Consequences'];
+const FILE_RE = /^(\d{4})-[a-z0-9]+(?:-[a-z0-9]+)*\.md$/;
+const STATUS_RE = /^(?:proposed|accepted|superseded by ADR-(\d{4}))$/;
+const INDEX_ROW_RE = /^\|\s*\[(\d{4})\]\(([^)]+)\)\s*\|\s*(.+?)\s*\|\s*(.+?)\s*\|\s*$/;
+
+const errors = [];
+const fail = (file, msg) => errors.push(`${file}: ${msg}`);
+
+const read = (file) => readFileSync(join(ADR_DIR, file), 'utf8');
+
+// Parse one ADR file. Records errors and returns its facts (or null when unparseable).
+function parseAdr(file) {
+  const num = file.slice(0, 4);
+  const lines = read(file).split('\n');
+
+  const h1 = lines.find((l) => l.startsWith('# '));
+  const h1Match = h1?.match(/^# ADR (\d{4}): (.+)$/);
+  if (!h1Match) {
+    fail(file, "missing or malformed H1 (expected '# ADR NNNN: <title>')");
+  } else if (h1Match[1] !== num) {
+    fail(file, `H1 number ${h1Match[1]} does not match filename number ${num}`);
+  }
+
+  let status = null;
+  let supersedes = null;
+  const statusLine = lines.find((l) => l.startsWith('> Status:'));
+  if (!statusLine) {
+    fail(
+      file,
+      "missing status line (expected '> Status: <status> · Date: <date> · Deciders: <names>')",
+    );
+  } else {
+    const m = statusLine.match(/^> Status:\s*(.+?)\s*·\s*Date:\s*(.+?)\s*(?:·.*)?$/);
+    if (!m) {
+      fail(file, "status line must be '> Status: <status> · Date: <date> · Deciders: <names>'");
+    } else {
+      status = m[1].trim();
+      const sm = status.match(STATUS_RE);
+      if (!sm) {
+        fail(file, `invalid status '${status}' (use proposed | accepted | superseded by ADR-NNNN)`);
+      } else if (sm[1]) {
+        supersedes = sm[1];
+      }
+      if (!/^\d{4}-\d{2}-\d{2}$/.test(m[2].trim())) {
+        fail(file, `date '${m[2].trim()}' must be ISO YYYY-MM-DD`);
+      }
+    }
+  }
+
+  const sections = new Set(lines.filter((l) => l.startsWith('## ')).map((l) => l.slice(3).trim()));
+  for (const s of REQUIRED_SECTIONS) {
+    if (!sections.has(s)) {
+      fail(file, `missing section '## ${s}'`);
+    }
+  }
+
+  return { num, file, title: h1Match ? h1Match[2].trim() : null, status, supersedes };
+}
+
+const entries = readdirSync(ADR_DIR).filter((f) => f.endsWith('.md'));
+
+// Filenames + collect decision ADRs (everything but the template and the index).
+const adrs = [];
+for (const file of entries) {
+  if (file === INDEX || file === TEMPLATE) {
+    continue;
+  }
+  if (!FILE_RE.test(file)) {
+    fail(file, 'filename must be NNNN-kebab-title.md');
+    continue;
+  }
+  adrs.push(parseAdr(file));
+}
+adrs.sort((a, b) => a.num.localeCompare(b.num));
+
+// Contiguous numbering from 0001.
+adrs.forEach((adr, i) => {
+  const expected = String(i + 1).padStart(4, '0');
+  if (adr.num !== expected) {
+    fail(adr.file, `numbering gap or duplicate: expected ${expected}, found ${adr.num}`);
+  }
+});
+
+// Superseding targets must exist.
+const byNum = new Map(adrs.map((a) => [a.num, a]));
+for (const adr of adrs) {
+  if (adr.supersedes && !byNum.has(adr.supersedes)) {
+    fail(adr.file, `superseded by ADR-${adr.supersedes}, which does not exist`);
+  }
+}
+
+// Index sync.
+const indexLines = read(INDEX).split('\n');
+const rows = new Map();
+for (const line of indexLines) {
+  const m = line.match(INDEX_ROW_RE);
+  if (!m) {
+    continue;
+  }
+  const [, num, link, title, statusCell] = m;
+  rows.set(num, { link, title: title.trim(), status: statusCell.trim() });
+  if (!entries.includes(link)) {
+    fail(INDEX, `index row ${num} links to '${link}', which does not exist`);
+  } else if (!link.startsWith(num)) {
+    fail(INDEX, `index row ${num} links to '${link}', whose number does not match`);
+  }
+}
+for (const adr of adrs) {
+  const row = rows.get(adr.num);
+  if (!row) {
+    fail(INDEX, `ADR ${adr.num} has no index row`);
+    continue;
+  }
+  if (adr.title && row.title !== adr.title) {
+    fail(INDEX, `index title for ${adr.num} ('${row.title}') does not match H1 ('${adr.title}')`);
+  }
+  if (adr.status && row.status !== adr.status) {
+    fail(
+      INDEX,
+      `index status for ${adr.num} ('${row.status}') does not match ADR ('${adr.status}')`,
+    );
+  }
+}
+// Orphan rows (a numbered row with no decision ADR), ignoring the 0000 template row.
+for (const num of rows.keys()) {
+  if (num !== '0000' && !byNum.has(num)) {
+    fail(INDEX, `index row ${num} has no matching ADR file`);
+  }
+}
+
+if (errors.length > 0) {
+  console.error(`ADR check failed (${errors.length} problem${errors.length === 1 ? '' : 's'}):`);
+  for (const e of errors) {
+    console.error(`  - ${e}`);
+  }
+  process.exit(1);
+}
+
+console.log(`ADR check passed: ${adrs.length} ADRs, index in sync.`);


### PR DESCRIPTION
## Why

ADRs already existed under `docs/adr/` (0001 establishing the practice, 0002-0009 a first backfill), but two gaps remained: nothing told an agent to write an ADR when a decision is made, and many load-bearing decisions had no record. This PR closes both.

## 1. Enforcement (the mechanism)

**Agent rule.** A `Decisions` section in `CLAUDE.md`, mirrored as one bullet in `.github/copilot-instructions.md`; the test and procedure stay single-sourced in ADR 0001. `AGENTS.md` already delegates to `CLAUDE.md`.

**CI guardrail** (`scripts/check-adrs.mjs`, `pnpm adr:check`, no-deps `adr` job). Validates the whole corpus: filename shape, contiguous numbering, the four required sections, valid status with existing supersede targets, and README index sync (presence, resolving links, title + status). It cannot judge when an ADR is *missing*; that stays with the reviewer.

## 2. Backfill (the content) — ADRs 0010-0024

Recorded against the actual code, each run through 0001's bar:

| Group | ADRs |
|-------|------|
| Architecture | 0010 ExecRunner seam · 0011 ErrPluginUnavailable contract |
| Testing | 0012 hermetic, deterministic testing (FixtureExecRunner + VT snapshots) |
| Toolchain | 0013 biome · 0014 vitest · 0015 tsup |
| Process | 0016 Conventional Commits gate · 0017 de-slop prose gate |
| Release | 0018 npm provenance + Homebrew tap · 0019 pinned Playwright container |
| Config & runtime | 0020 Node 20/ES2022 · 0021 config path resolution · 0022 durable config writes · 0023 semver-first version compare · 0024 Sandcastle orchestration |

The guardrail dogfoods the backfill: `pnpm adr:check` passes at **24 ADRs, index in sync**.

## Verification
- `pnpm adr:check` green; a negative fixture (stale index status, missing section, numbering gap) was caught with precise messages.
- `pnpm lint` (biome) clean; de-slop on the changed Markdown reports **0 errors** (a couple of warn-tier notes, consistent with the existing corpus).

Branched off `develop` (the ADR system does not exist on `main`); targets `develop`.