### PR TITLE
feat(cli): add --doctor self-diagnostic (#42)

### DIFF
--- a/apps/cli/src/cli.ts
+++ b/apps/cli/src/cli.ts
@@ -28,6 +28,7 @@ import type { FlagAction } from './cli/types';
 import { CleanupAction } from './commands/cleanup';
 import { CompletionsAction } from './commands/completions';
 import { ConfigAction } from './commands/config';
+import { DoctorAction } from './commands/doctor';
 import { commandsFromManifest } from './commands/from-manifest';
 import { InstallCompletionsAction } from './commands/install-completions';
 import { LogoAction } from './commands/logo';
@@ -88,6 +89,7 @@ const flagActions: readonly FlagAction[] = [
   new ConfigAction(),
   new CleanupAction(),
   new RestoreAction(),
+  new DoctorAction(),
 ];
 
 const pluginSubCommands: Record<string, ReturnType<typeof commandsFromManifest>> = {};

--- a/apps/cli/src/cli/argv.ts
+++ b/apps/cli/src/cli/argv.ts
@@ -20,6 +20,7 @@ export const FLAG_COMMAND_ALIASES = [
   'config',
   'cleanup',
   'restore',
+  'doctor',
   'logo',
   'plugins',
   'install-completions',

--- a/apps/cli/src/commands/doctor.ts
+++ b/apps/cli/src/commands/doctor.ts
@@ -80,15 +80,19 @@ export class DoctorAction implements FlagAction {
       description:
         'Run a self-diagnostic report: environment, config, plugin probes, data integrity, shell integration.',
     },
-    json: {
-      type: 'boolean' as const,
-      description: 'With --doctor: emit the report as JSON.',
-    },
   };
 
   matches(args: ParsedArgs): boolean {
     return args.doctor === true;
   }
 
-  run = runDoctor;
+  // `--json` is deliberately NOT a registered root arg. Registering it
+  // would shadow subcommand `--json` (e.g. `macup outdated --json`) and
+  // make bare `macup --json` a "known" flag that skips the unknown-flag
+  // guard and silently opens the wizard. Instead read it from argv here;
+  // citty accepts the unrecognised `--json` on the root command
+  // permissively, and this action only runs when `--doctor` is present.
+  run(args: ParsedArgs, deps: CliDeps): Promise<void> {
+    return runDoctor({ ...args, json: process.argv.includes('--json') }, deps);
+  }
 }

--- a/apps/cli/src/commands/doctor.ts
+++ b/apps/cli/src/commands/doctor.ts
@@ -1,0 +1,94 @@
+// `macup --doctor` — sectioned self-diagnostic (issue #42).
+//
+// Orchestration only: assemble CheckDeps from the CLI's runtime bag,
+// run the five check modules in parallel, and render. The checks live
+// in doctor/checks/*.ts and the report shape + renderers in
+// doctor/report.ts. Exit semantics: 0 when clean or warnings-only, 1 on
+// any error — warnings never fail the exit.
+
+import { release } from 'node:os';
+import type { CliDeps, FlagAction, ParsedArgs } from '../cli/types';
+import { BUILTIN_PLUGINS } from '../plugins/registry';
+import { getVersion } from '../version';
+import { check as checkConfig } from './doctor/checks/config';
+import { check as checkDataIntegrity } from './doctor/checks/data-integrity';
+import { check as checkEnvironment } from './doctor/checks/environment';
+import { check as checkPlugins } from './doctor/checks/plugins';
+import { check as checkShellIntegration } from './doctor/checks/shell-integration';
+import {
+  type CheckDeps,
+  type DoctorReport,
+  buildReport,
+  exitCodeFor,
+  renderJson,
+  renderText,
+} from './doctor/report';
+
+export { exitCodeFor, renderJson, renderText };
+export type { CheckDeps, DoctorReport };
+
+/** Hard cap per plugin list() probe. */
+export const DOCTOR_PROBE_TIMEOUT_MS = 15_000;
+
+const CHECKS = [
+  checkEnvironment,
+  checkConfig,
+  checkPlugins,
+  checkDataIntegrity,
+  checkShellIntegration,
+] as const;
+
+export async function runDoctorChecks(deps: CheckDeps): Promise<DoctorReport> {
+  const sections = await Promise.all(CHECKS.map((check) => check(deps)));
+  return buildReport(deps.macupVersion, sections);
+}
+
+export async function runDoctor(args: ParsedArgs, deps: CliDeps): Promise<void> {
+  const checkDeps: CheckDeps = {
+    env: deps.env,
+    home: deps.home,
+    exec: deps.exec,
+    // Probe chatter (e.g. a plugin's list() warning) becomes CheckResults;
+    // loose console lines would corrupt --json output.
+    log: { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} },
+    signal: deps.signal,
+    // Every built-in gets deep-probed, not just the registry-filtered
+    // set — a missing binary should show up as a warning, not vanish.
+    // The composite `all` is excluded: probing it re-runs each backend.
+    plugins: BUILTIN_PLUGINS.filter((p) => p.manifest.id !== 'all'),
+    paths: deps.resolvePaths(),
+    platform: process.platform,
+    arch: process.arch,
+    osRelease: release(),
+    nodeVersion: process.version,
+    macupVersion: getVersion(),
+    probeTimeoutMs: DOCTOR_PROBE_TIMEOUT_MS,
+  };
+
+  const report = await runDoctorChecks(checkDeps);
+  console.log(args.json === true ? renderJson(report) : renderText(report));
+  process.exitCode = exitCodeFor(report);
+}
+
+export class DoctorAction implements FlagAction {
+  readonly name = 'doctor';
+  readonly description =
+    'Run a self-diagnostic report: environment, config, plugin probes, data integrity, shell integration.';
+  readonly args = {
+    doctor: {
+      type: 'boolean' as const,
+      description:
+        'Run a self-diagnostic report: environment, config, plugin probes, data integrity, shell integration.',
+    },
+    json: {
+      type: 'boolean' as const,
+      description: 'With --doctor: emit the report as JSON.',
+    },
+  };
+
+  matches(args: ParsedArgs): boolean {
+    return args.doctor === true;
+  }
+
+  run = runDoctor;
+}

--- a/apps/cli/src/commands/doctor/checks/config.ts
+++ b/apps/cli/src/commands/doctor/checks/config.ts
@@ -24,14 +24,17 @@ function checkConfigDir(deps: CheckDeps): CheckResult {
     return { level: 'ok', label: 'Config dir', detail: `${dir} — not created yet` };
   }
   try {
-    accessSync(dir, constants.W_OK);
+    // A directory needs execute as well as write to create/replace entries
+    // inside it; W_OK alone can call a dir writable when macup still can't
+    // write the applist. Check both.
+    accessSync(dir, constants.W_OK | constants.X_OK);
     return { level: 'ok', label: 'Config dir', detail: `${dir} — writable` };
   } catch {
     return {
       level: 'error',
       label: 'Config dir',
       detail: `${dir} — not writable`,
-      hint: `run: chmod u+w ${dir}`,
+      hint: `run: chmod u+wx ${dir}`,
     };
   }
 }

--- a/apps/cli/src/commands/doctor/checks/config.ts
+++ b/apps/cli/src/commands/doctor/checks/config.ts
@@ -4,7 +4,7 @@
 // buildConfigReport from the --config command so the two surfaces can't
 // drift on what "valid" means.
 
-import { accessSync, constants, existsSync } from 'node:fs';
+import { constants, accessSync, existsSync } from 'node:fs';
 import { readdir, stat } from 'node:fs/promises';
 import { join } from 'node:path';
 import { buildConfigReport } from '../../config';

--- a/apps/cli/src/commands/doctor/checks/config.ts
+++ b/apps/cli/src/commands/doctor/checks/config.ts
@@ -1,0 +1,110 @@
+// Doctor section 2: Config — config dir writable, applist.yaml parses
+// and validates against the zod schema (the Zod error is shown in
+// detail, not swallowed), backup dir with count + size. Reuses
+// buildConfigReport from the --config command so the two surfaces can't
+// drift on what "valid" means.
+
+import { accessSync, constants, existsSync } from 'node:fs';
+import { readdir, stat } from 'node:fs/promises';
+import { join } from 'node:path';
+import { buildConfigReport } from '../../config';
+import type { CheckDeps, CheckResult, Section } from '../report';
+import { errorMessage } from './probe';
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  const kb = bytes / 1024;
+  if (kb < 1024) return `${kb.toFixed(1)} KB`;
+  return `${(kb / 1024).toFixed(1)} MB`;
+}
+
+function checkConfigDir(deps: CheckDeps): CheckResult {
+  const dir = deps.paths.configDir;
+  if (!existsSync(dir)) {
+    return { level: 'ok', label: 'Config dir', detail: `${dir} — not created yet` };
+  }
+  try {
+    accessSync(dir, constants.W_OK);
+    return { level: 'ok', label: 'Config dir', detail: `${dir} — writable` };
+  } catch {
+    return {
+      level: 'error',
+      label: 'Config dir',
+      detail: `${dir} — not writable`,
+      hint: `run: chmod u+w ${dir}`,
+    };
+  }
+}
+
+async function checkBackups(deps: CheckDeps): Promise<CheckResult> {
+  const dir = deps.paths.backupDir;
+  let entries: string[];
+  try {
+    entries = await readdir(dir);
+  } catch (err) {
+    if (err && typeof err === 'object' && 'code' in err && err.code === 'ENOENT') {
+      return { level: 'ok', label: 'Backups', detail: `${dir} — none yet` };
+    }
+    // Unreadable backup dir is a warning, not a crash (issue #42).
+    return { level: 'warn', label: 'Backups', detail: `${dir} — unreadable: ${errorMessage(err)}` };
+  }
+
+  let bytes = 0;
+  let count = 0;
+  for (const name of entries) {
+    try {
+      const s = await stat(join(dir, name));
+      if (!s.isFile()) continue;
+      count++;
+      bytes += s.size;
+    } catch {
+      // A vanished or unreadable entry shouldn't sink the whole check.
+    }
+  }
+  return {
+    level: 'ok',
+    label: 'Backups',
+    detail: `${count} file${count === 1 ? '' : 's'}, ${formatBytes(bytes)} (${dir})`,
+  };
+}
+
+export async function check(deps: CheckDeps): Promise<Section> {
+  const results: CheckResult[] = [];
+  results.push(checkConfigDir(deps));
+
+  const report = await buildConfigReport(deps.paths);
+  if (!report.exists) {
+    results.push({
+      level: 'ok',
+      label: 'applist.yaml',
+      detail: `${report.applistPath} — not created yet (defaults apply)`,
+    });
+  } else if (report.schemaValid) {
+    results.push({
+      level: 'ok',
+      label: 'applist.yaml',
+      detail: `${report.applistPath} — valid (${report.pinsCount} pins, ${report.skipCount} skips)`,
+    });
+  } else {
+    results.push({
+      level: 'error',
+      label: 'applist.yaml',
+      detail: `${report.applistPath} — ${report.schemaError ?? 'failed validation'}`,
+      hint: 'fix the schema error, or restore a backup: macup --restore',
+    });
+  }
+
+  if (report.deprecationWarning) {
+    results.push({ level: 'warn', label: 'Config source', detail: report.deprecationWarning });
+  }
+  if (report.legacyMigration) {
+    results.push({
+      level: 'warn',
+      label: 'Legacy config',
+      detail: `${report.legacyMigration.from} will be migrated to ${report.legacyMigration.to} on first mutation`,
+    });
+  }
+
+  results.push(await checkBackups(deps));
+  return { title: 'Config', results };
+}

--- a/apps/cli/src/commands/doctor/checks/data-integrity.ts
+++ b/apps/cli/src/commands/doctor/checks/data-integrity.ts
@@ -153,7 +153,9 @@ export async function check(deps: CheckDeps): Promise<Section> {
   if (applist === 'missing') {
     return {
       title,
-      results: [{ level: 'ok', label: 'Tracked packages', detail: 'no applist yet — nothing to verify' }],
+      results: [
+        { level: 'ok', label: 'Tracked packages', detail: 'no applist yet — nothing to verify' },
+      ],
     };
   }
   if (applist === 'invalid') {

--- a/apps/cli/src/commands/doctor/checks/data-integrity.ts
+++ b/apps/cli/src/commands/doctor/checks/data-integrity.ts
@@ -1,0 +1,183 @@
+// Doctor section 4: Data integrity (deep) — for every tracked package,
+// call plugin.list({}) and assert the name still resolves against the
+// underlying tool. Everything here is a warning, never an error: a
+// stale pin or an uninstalled tracked package is drift to surface, not
+// a broken installation (a genuinely broken plugin already errors in
+// the Plugins section — double-reporting it here would double-count one
+// root cause).
+
+import { readFile } from 'node:fs/promises';
+import semver from 'semver';
+import { parse } from 'yaml';
+import { type Applist, type ApplistKey, ApplistSchema } from '../../../config/schema';
+import type { Plugin } from '../../../plugins/types';
+import type { CheckDeps, CheckResult, Section } from '../report';
+import { missingBinaries, probeList } from './probe';
+
+function trackedFor(applist: Applist, key: ApplistKey): readonly string[] {
+  switch (key) {
+    case 'appstore':
+      return applist.appstore;
+    case 'npm':
+      return applist.npm;
+    case 'pnpm':
+      return applist.pnpm;
+    case 'brew.formulas':
+      return applist.brew.formulas;
+    case 'brew.casks':
+      return applist.brew.casks;
+  }
+}
+
+// Same permissive stance as src/plugins/selection.ts: pins can be
+// non-semver strings (brew date versions, mas build IDs); when a plugin
+// has no comparator of its own and the strings aren't semver, treat
+// them as equal so a malformed pin never flags spuriously.
+function compareVersions(plugin: Plugin, a: string, b: string): -1 | 0 | 1 {
+  const custom = plugin.manifest.compareVersions;
+  if (custom) return custom(a, b);
+  if (semver.valid(a) && semver.valid(b)) {
+    const result = semver.compare(a, b);
+    if (result < 0) return -1;
+    if (result > 0) return 1;
+  }
+  return 0;
+}
+
+async function loadApplist(deps: CheckDeps): Promise<Applist | 'missing' | 'invalid'> {
+  let text: string;
+  try {
+    text = await readFile(deps.paths.applistPath, 'utf8');
+  } catch {
+    return 'missing';
+  }
+  try {
+    const parsed = ApplistSchema.safeParse(parse(text) ?? {});
+    return parsed.success ? parsed.data : 'invalid';
+  } catch {
+    return 'invalid';
+  }
+}
+
+async function verifyPlugin(
+  plugin: Plugin,
+  applist: Applist,
+  deps: CheckDeps,
+): Promise<CheckResult[]> {
+  const m = plugin.manifest;
+  const tracked = m.configKeys.flatMap((key) => [...trackedFor(applist, key)]);
+  const pins = applist.pins[m.id] ?? {};
+  const skips = applist.skip[m.id] ?? [];
+  if (tracked.length === 0 && Object.keys(pins).length === 0 && skips.length === 0) {
+    return [];
+  }
+
+  if (!m.supportedOS.includes(deps.platform) || missingBinaries(plugin, deps).length > 0) {
+    return [
+      {
+        level: 'warn',
+        label: m.id,
+        detail: `${tracked.length} tracked package${tracked.length === 1 ? '' : 's'} not verified — plugin unavailable`,
+      },
+    ];
+  }
+
+  const outcome = await probeList(plugin, deps, {});
+  if (outcome.kind !== 'ok') {
+    const reason =
+      outcome.kind === 'timeout'
+        ? `list timed out after ${Math.round(deps.probeTimeoutMs / 1000)}s`
+        : outcome.message;
+    return [{ level: 'warn', label: m.id, detail: `not verified — ${reason}` }];
+  }
+
+  const installed = new Map<string, string | undefined>();
+  for (const s of outcome.statuses) installed.set(s.ref.name, s.installedVersion);
+  const trackedSet = new Set(tracked);
+  const results: CheckResult[] = [];
+
+  for (const name of tracked) {
+    if (installed.has(name)) continue;
+    results.push({
+      level: 'warn',
+      label: 'Not installed',
+      detail: `${m.id}:${name} tracked but not installed`,
+      hint: `run: macup ${m.id} install ${name}`,
+    });
+  }
+
+  for (const [name, pin] of Object.entries(pins)) {
+    if (!trackedSet.has(name)) {
+      results.push({
+        level: 'warn',
+        label: 'Stale pin',
+        detail: `${m.id}:${name} pinned ${pin} but not in tracked list`,
+        hint: `run: macup ${m.id} unpin ${name}`,
+      });
+      continue;
+    }
+    const installedVersion = installed.get(name);
+    if (installedVersion && compareVersions(plugin, installedVersion, pin) > 0) {
+      results.push({
+        level: 'warn',
+        label: 'Stale pin',
+        detail: `${m.id}:${name} pinned ${pin} but ${installedVersion} is already installed`,
+        hint: `run: macup ${m.id} unpin ${name}`,
+      });
+    }
+  }
+
+  for (const name of skips) {
+    if (trackedSet.has(name)) continue;
+    results.push({
+      level: 'warn',
+      label: 'Stale skip',
+      detail: `${m.id}:${name} skipped but not in tracked list`,
+      hint: `run: macup ${m.id} unskip ${name}`,
+    });
+  }
+
+  if (results.length === 0) {
+    results.push({
+      level: 'ok',
+      label: m.id,
+      detail: `${tracked.length} tracked package${tracked.length === 1 ? '' : 's'} resolve`,
+    });
+  }
+  return results;
+}
+
+export async function check(deps: CheckDeps): Promise<Section> {
+  const title = 'Data integrity';
+  const applist = await loadApplist(deps);
+  if (applist === 'missing') {
+    return {
+      title,
+      results: [{ level: 'ok', label: 'Tracked packages', detail: 'no applist yet — nothing to verify' }],
+    };
+  }
+  if (applist === 'invalid') {
+    // The Config section carries the schema error itself.
+    return {
+      title,
+      results: [
+        {
+          level: 'warn',
+          label: 'Tracked packages',
+          detail: 'not verified — applist.yaml failed validation (see Config)',
+        },
+      ],
+    };
+  }
+
+  const perPlugin = await Promise.all(
+    deps.plugins
+      .filter((p) => p.manifest.configKeys.length > 0)
+      .map((p) => verifyPlugin(p, applist, deps)),
+  );
+  const results = perPlugin.flat();
+  if (results.length === 0) {
+    results.push({ level: 'ok', label: 'Tracked packages', detail: 'nothing tracked yet' });
+  }
+  return { title, results };
+}

--- a/apps/cli/src/commands/doctor/checks/environment.ts
+++ b/apps/cli/src/commands/doctor/checks/environment.ts
@@ -1,0 +1,47 @@
+// Doctor section 1: Environment — orientation info for bug reports.
+// macOS version, shell, Node (error if < 20, matching the engines
+// field), and the macup version itself.
+
+import type { CheckDeps, CheckResult, Section } from '../report';
+
+const MIN_NODE_MAJOR = 20;
+
+export async function check(deps: CheckDeps): Promise<Section> {
+  const results: CheckResult[] = [];
+
+  const osDetail = `${deps.platform} ${deps.osRelease} (${deps.arch})`;
+  if (deps.platform === 'darwin') {
+    results.push({ level: 'ok', label: 'macOS', detail: osDetail });
+  } else {
+    results.push({
+      level: 'warn',
+      label: 'macOS',
+      detail: osDetail,
+      hint: 'macup built-in plugins support macOS (darwin) only',
+    });
+  }
+
+  const shell = deps.env.SHELL;
+  if (shell) {
+    results.push({ level: 'ok', label: 'Shell', detail: shell });
+  } else {
+    results.push({ level: 'warn', label: 'Shell', detail: '$SHELL is not set' });
+  }
+
+  const major = Number.parseInt(deps.nodeVersion.replace(/^v/, ''), 10);
+  const nodeDetail = `${deps.nodeVersion} (>= ${MIN_NODE_MAJOR} required)`;
+  if (Number.isFinite(major) && major >= MIN_NODE_MAJOR) {
+    results.push({ level: 'ok', label: 'Node', detail: nodeDetail });
+  } else {
+    results.push({
+      level: 'error',
+      label: 'Node',
+      detail: nodeDetail,
+      hint: `upgrade Node to ${MIN_NODE_MAJOR} or later`,
+    });
+  }
+
+  results.push({ level: 'ok', label: 'macup', detail: `v${deps.macupVersion}` });
+
+  return { title: 'Environment', results };
+}

--- a/apps/cli/src/commands/doctor/checks/plugins.ts
+++ b/apps/cli/src/commands/doctor/checks/plugins.ts
@@ -1,0 +1,84 @@
+// Doctor section 3: Plugins (deep) — for every built-in plugin, not just
+// the registry-filtered set: binary on PATH → version probe → an actual
+// plugin.list({ onlyOutdated: true }) call under a timeout. "Installed"
+// is not "working". A missing binary is a warning (the plugin is simply
+// disabled); a list() that throws anything other than
+// ErrPluginUnavailable is an error.
+
+import { pathTo } from '../../../plugins/registry';
+import type { Plugin } from '../../../plugins/types';
+import type { CheckDeps, CheckResult, Section } from '../report';
+import { missingBinaries, probeList } from './probe';
+
+// Best-effort `<bin> --version` for the report line ("Homebrew 4.2.7").
+// Purely decorative: some backends (softwareupdate) have no version
+// flag, so any failure just drops the detail back to the display name.
+async function probeVersion(bin: string, deps: CheckDeps): Promise<string | undefined> {
+  try {
+    const r = await deps.exec.run(bin, ['--version'], { kind: 'check', signal: deps.signal });
+    if (r.exitCode !== 0) return undefined;
+    const first = r.stdout.trim().split('\n')[0]?.trim();
+    return first || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+async function probePlugin(plugin: Plugin, deps: CheckDeps): Promise<CheckResult> {
+  const m = plugin.manifest;
+
+  if (!m.supportedOS.includes(deps.platform)) {
+    return {
+      level: 'warn',
+      label: m.id,
+      detail: `unsupported on ${deps.platform} (needs ${m.supportedOS.join('/')})`,
+    };
+  }
+
+  const missing = missingBinaries(plugin, deps);
+  if (missing.length > 0) {
+    return {
+      level: 'warn',
+      label: m.id,
+      detail: `\`${missing.join('`, `')}\` not on PATH — plugin disabled`,
+    };
+  }
+
+  const bin = m.requires[0];
+  let detail = m.displayName;
+  if (bin) {
+    const version = await probeVersion(bin, deps);
+    const binPath = pathTo(bin, deps.env);
+    if (version) detail = binPath ? `${version} (${binPath})` : version;
+    else if (binPath) detail = `${m.displayName} (${binPath})`;
+  }
+
+  const outcome = await probeList(plugin, deps, { onlyOutdated: true });
+  switch (outcome.kind) {
+    case 'ok': {
+      const n = outcome.statuses.length;
+      return {
+        level: 'ok',
+        label: m.id,
+        detail,
+        hint: `list probe: ${n} outdated package${n === 1 ? '' : 's'}`,
+      };
+    }
+    case 'unavailable':
+      return { level: 'warn', label: m.id, detail: outcome.message };
+    case 'timeout':
+      return {
+        level: 'warn',
+        label: m.id,
+        detail,
+        hint: `list probe timed out after ${Math.round(deps.probeTimeoutMs / 1000)}s`,
+      };
+    case 'failed':
+      return { level: 'error', label: m.id, detail: `list probe failed: ${outcome.message}` };
+  }
+}
+
+export async function check(deps: CheckDeps): Promise<Section> {
+  const results = await Promise.all(deps.plugins.map((p) => probePlugin(p, deps)));
+  return { title: 'Plugins', results };
+}

--- a/apps/cli/src/commands/doctor/checks/probe.ts
+++ b/apps/cli/src/commands/doctor/checks/probe.ts
@@ -1,0 +1,67 @@
+// Shared plugin-probe plumbing for the deep checks (plugins.ts and
+// data-integrity.ts). A probe actually calls plugin.list() — "installed"
+// is not "working" — under a hard timeout, and classifies the outcome so
+// the checks can map it to a CheckResult level without re-implementing
+// the error taxonomy: ErrPluginUnavailable is a warning (missing backend,
+// per the plugin contract), a timeout is a warning (slow ≠ broken), and
+// anything else thrown by list() is a genuine error.
+
+import { ErrPluginUnavailable } from '../../../errors';
+import type { ListOptions, PackageStatus, Plugin } from '../../../plugins/types';
+import type { CheckDeps } from '../report';
+
+export type ProbeOutcome =
+  | { kind: 'ok'; statuses: PackageStatus[] }
+  | { kind: 'unavailable'; message: string }
+  | { kind: 'timeout' }
+  | { kind: 'failed'; message: string };
+
+/** list() may throw non-Error values — coerce via String() (issue #42). */
+export function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+class ProbeTimeoutError extends Error {
+  constructor(ms: number) {
+    super(`probe timed out after ${Math.round(ms / 1000)}s`);
+  }
+}
+
+export async function probeList(
+  plugin: Plugin,
+  deps: CheckDeps,
+  opts: ListOptions,
+): Promise<ProbeOutcome> {
+  // Per-probe controller chained to the process-wide signal so both a
+  // SIGINT and the probe timeout cancel the underlying subprocess.
+  const controller = new AbortController();
+  const onAbort = () => controller.abort();
+  deps.signal.addEventListener('abort', onAbort, { once: true });
+  const ctx = { exec: deps.exec, log: deps.log, signal: controller.signal };
+
+  let timer: NodeJS.Timeout | undefined;
+  try {
+    const statuses = await Promise.race([
+      plugin.list(ctx, opts),
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(() => {
+          controller.abort();
+          reject(new ProbeTimeoutError(deps.probeTimeoutMs));
+        }, deps.probeTimeoutMs);
+      }),
+    ]);
+    return { kind: 'ok', statuses };
+  } catch (err) {
+    if (err instanceof ProbeTimeoutError) return { kind: 'timeout' };
+    if (err instanceof ErrPluginUnavailable) return { kind: 'unavailable', message: err.message };
+    return { kind: 'failed', message: errorMessage(err) };
+  } finally {
+    if (timer) clearTimeout(timer);
+    deps.signal.removeEventListener('abort', onAbort);
+  }
+}
+
+/** Binaries from manifest.requires missing on PATH (per the exec runner). */
+export function missingBinaries(plugin: Plugin, deps: CheckDeps): string[] {
+  return plugin.manifest.requires.filter((bin) => !deps.exec.onPath(bin));
+}

--- a/apps/cli/src/commands/doctor/checks/probe.ts
+++ b/apps/cli/src/commands/doctor/checks/probe.ts
@@ -33,10 +33,13 @@ export async function probeList(
   opts: ListOptions,
 ): Promise<ProbeOutcome> {
   // Per-probe controller chained to the process-wide signal so both a
-  // SIGINT and the probe timeout cancel the underlying subprocess.
+  // SIGINT and the probe timeout cancel the underlying subprocess. If the
+  // signal already fired before we got here, the listener would never run
+  // — so propagate the existing abort immediately.
   const controller = new AbortController();
   const onAbort = () => controller.abort();
-  deps.signal.addEventListener('abort', onAbort, { once: true });
+  if (deps.signal.aborted) controller.abort();
+  else deps.signal.addEventListener('abort', onAbort, { once: true });
   const ctx = { exec: deps.exec, log: deps.log, signal: controller.signal };
 
   let timer: NodeJS.Timeout | undefined;

--- a/apps/cli/src/commands/doctor/checks/shell-integration.ts
+++ b/apps/cli/src/commands/doctor/checks/shell-integration.ts
@@ -1,0 +1,36 @@
+// Doctor section 5: Shell integration — detect the current shell from
+// $SHELL and check whether a completions file exists at the path
+// --install-completions would write to. Missing completions are a
+// warning whose hint is the one-liner that fixes it.
+
+import { existsSync } from 'node:fs';
+import { resolveInstallPath } from '../../install-completions';
+import { SUPPORTED_SHELLS, detectShellFromEnv } from '../../shell';
+import type { CheckDeps, CheckResult, Section } from '../report';
+
+export async function check(deps: CheckDeps): Promise<Section> {
+  const title = 'Shell integration';
+  const shell = detectShellFromEnv(deps.env);
+  if (!shell) {
+    const detail = deps.env.SHELL
+      ? `unsupported shell ${deps.env.SHELL} — completions unavailable`
+      : 'could not detect shell — $SHELL is not set';
+    return {
+      title,
+      results: [
+        { level: 'warn', label: 'Completions', detail, hint: `supported: ${SUPPORTED_SHELLS.join(', ')}` },
+      ],
+    };
+  }
+
+  const path = resolveInstallPath(shell, { home: deps.home, env: deps.env });
+  const result: CheckResult = existsSync(path)
+    ? { level: 'ok', label: 'Completions', detail: `${shell} — installed at ${path}` }
+    : {
+        level: 'warn',
+        label: 'Completions',
+        detail: `${shell} — not installed`,
+        hint: `run: macup --install-completions=${shell}`,
+      };
+  return { title, results: [result] };
+}

--- a/apps/cli/src/commands/doctor/checks/shell-integration.ts
+++ b/apps/cli/src/commands/doctor/checks/shell-integration.ts
@@ -18,7 +18,12 @@ export async function check(deps: CheckDeps): Promise<Section> {
     return {
       title,
       results: [
-        { level: 'warn', label: 'Completions', detail, hint: `supported: ${SUPPORTED_SHELLS.join(', ')}` },
+        {
+          level: 'warn',
+          label: 'Completions',
+          detail,
+          hint: `supported: ${SUPPORTED_SHELLS.join(', ')}`,
+        },
       ],
     };
   }

--- a/apps/cli/src/commands/doctor/report.ts
+++ b/apps/cli/src/commands/doctor/report.ts
@@ -1,0 +1,109 @@
+// Typed report shape + renderers for `macup --doctor` (issue #42).
+//
+// Every check module (checks/*.ts) exports a uniform
+// `check(deps: CheckDeps): Promise<Section>`; the orchestrator in
+// ../doctor.ts runs them in parallel and hands the collected sections
+// to the renderers here. Text output goes through the color-aware
+// glyphs in src/ui/log so NO_COLOR / non-TTY stripping works the same
+// as everywhere else; JSON output is plain and uniform across
+// environments (it feeds bug reports and CI).
+
+import type { PathResolution } from '../../config/paths';
+import type { ExecRunner, Logger, Plugin } from '../../plugins/types';
+import * as logui from '../../ui/log';
+
+export type CheckLevel = 'ok' | 'warn' | 'error';
+
+export interface CheckResult {
+  level: CheckLevel;
+  label: string;
+  detail?: string;
+  /** Actionable next step, rendered dimmed under the line. */
+  hint?: string;
+}
+
+export interface Section {
+  title: string;
+  results: readonly CheckResult[];
+}
+
+/** Everything a check needs, injected so tests can drive the checks
+ * against a FixtureExecRunner + tmp dirs without touching the machine. */
+export interface CheckDeps {
+  readonly env: NodeJS.ProcessEnv;
+  readonly home: string;
+  readonly exec: ExecRunner;
+  /** Logger handed to plugin probes. Doctor passes a silent one — probe
+   * chatter becomes CheckResults, not loose console lines. */
+  readonly log: Logger;
+  readonly signal: AbortSignal;
+  /** Plugins to deep-probe. The orchestrator passes every built-in
+   * except the composite `all` (probing it would re-run each backend). */
+  readonly plugins: readonly Plugin[];
+  readonly paths: PathResolution;
+  readonly platform: NodeJS.Platform;
+  readonly arch: string;
+  readonly osRelease: string;
+  /** e.g. 'v22.11.0' (process.version). */
+  readonly nodeVersion: string;
+  readonly macupVersion: string;
+  /** Hard cap per plugin list() probe. */
+  readonly probeTimeoutMs: number;
+}
+
+export interface DoctorSummary {
+  ok: number;
+  warnings: number;
+  errors: number;
+}
+
+export interface DoctorReport {
+  version: string;
+  sections: readonly Section[];
+  summary: DoctorSummary;
+}
+
+export function buildReport(version: string, sections: readonly Section[]): DoctorReport {
+  const summary: DoctorSummary = { ok: 0, warnings: 0, errors: 0 };
+  for (const section of sections) {
+    for (const r of section.results) {
+      if (r.level === 'ok') summary.ok++;
+      else if (r.level === 'warn') summary.warnings++;
+      else summary.errors++;
+    }
+  }
+  return { version, sections, summary };
+}
+
+/** Warnings never fail the exit — only errors do (issue #42). */
+export function exitCodeFor(report: DoctorReport): 0 | 1 {
+  return report.summary.errors > 0 ? 1 : 0;
+}
+
+function glyphFor(level: CheckLevel): string {
+  if (level === 'ok') return logui.SYM.success;
+  if (level === 'warn') return logui.SYM.warning;
+  return logui.SYM.error;
+}
+
+export function renderText(report: DoctorReport): string {
+  const lines: string[] = [];
+  for (const section of report.sections) {
+    if (lines.length > 0) lines.push('');
+    lines.push(`${section.title.toUpperCase()}:`);
+    const pad = Math.max(12, ...section.results.map((r) => r.label.length));
+    for (const r of section.results) {
+      const detail = r.detail ? `  ${r.detail}` : '';
+      lines.push(`  ${glyphFor(r.level)} ${r.label.padEnd(pad)}${detail}`);
+      if (r.hint) lines.push(logui.trace(r.hint));
+    }
+  }
+  const { ok, warnings, errors } = report.summary;
+  lines.push('');
+  lines.push(`SUMMARY: ${ok} ok, ${warnings} warning${warnings === 1 ? '' : 's'}, ${errors} error${errors === 1 ? '' : 's'}`);
+  return lines.join('\n');
+}
+
+export function renderJson(report: DoctorReport): string {
+  return JSON.stringify(report, null, 2);
+}

--- a/apps/cli/src/commands/doctor/report.ts
+++ b/apps/cli/src/commands/doctor/report.ts
@@ -100,7 +100,9 @@ export function renderText(report: DoctorReport): string {
   }
   const { ok, warnings, errors } = report.summary;
   lines.push('');
-  lines.push(`SUMMARY: ${ok} ok, ${warnings} warning${warnings === 1 ? '' : 's'}, ${errors} error${errors === 1 ? '' : 's'}`);
+  lines.push(
+    `SUMMARY: ${ok} ok, ${warnings} warning${warnings === 1 ? '' : 's'}, ${errors} error${errors === 1 ? '' : 's'}`,
+  );
   return lines.join('\n');
 }
 

--- a/apps/cli/src/meta.ts
+++ b/apps/cli/src/meta.ts
@@ -120,6 +120,11 @@ const GLOBAL_FLAGS: GlobalFlagDoc[] = [
   },
   { flag: '--cleanup', description: 'Delete all config backup files (with confirmation).' },
   { flag: '--restore', description: 'Interactively pick and restore a config backup.' },
+  {
+    flag: '--doctor',
+    description:
+      'Run a self-diagnostic report: environment, config, plugin probes, data integrity, shell integration. Add `--json` for machine-readable output. Exits 1 on errors; warnings never fail.',
+  },
   { flag: '--logo', description: 'Print the macup logo splash.' },
 ];
 

--- a/apps/cli/src/plugins/registry.ts
+++ b/apps/cli/src/plugins/registry.ts
@@ -30,22 +30,31 @@ export function buildRegistry(plugins: readonly Plugin[], deps: RegistryDeps): P
 }
 
 /**
- * Minimal `which`-style check: does `binary` exist as an executable on
- * any $PATH entry? Used as the default onPath for the registry; tests
- * can override by passing a custom onPath.
+ * Minimal `which`-style lookup: the first $PATH entry where `binary`
+ * exists as an executable, or undefined. `--doctor` uses the resolved
+ * path in its plugin report lines.
  */
-export function isOnPath(binary: string, env: NodeJS.ProcessEnv = process.env): boolean {
+export function pathTo(binary: string, env: NodeJS.ProcessEnv = process.env): string | undefined {
   const pathValue = env.PATH ?? '';
   const paths = pathValue.split(delimiter).filter(Boolean);
   for (const dir of paths) {
     try {
-      accessSync(join(dir, binary), constants.X_OK);
-      return true;
+      const candidate = join(dir, binary);
+      accessSync(candidate, constants.X_OK);
+      return candidate;
     } catch {
       // keep searching
     }
   }
-  return false;
+  return undefined;
+}
+
+/**
+ * Boolean form of pathTo. Used as the default onPath for the registry;
+ * tests can override by passing a custom onPath.
+ */
+export function isOnPath(binary: string, env: NodeJS.ProcessEnv = process.env): boolean {
+  return pathTo(binary, env) !== undefined;
 }
 
 /**

--- a/apps/cli/test/integration/commands/doctor.test.ts
+++ b/apps/cli/test/integration/commands/doctor.test.ts
@@ -122,3 +122,25 @@ describe('doctor — plugins deep probe', () => {
     expect(exitCodeFor(buildReport('1', [section]))).toBe(1);
   });
 });
+
+describe('doctor — probe cancellation', () => {
+  it('propagates an already-aborted signal to the probe controller', async () => {
+    const controller = new AbortController();
+    controller.abort(); // aborted before the probe even starts
+    const exec = new FixtureExecRunner({
+      fixtures: [
+        { cmd: 'demo', args: ['--version'], result: { stdout: 'demo 1', stderr: '', exitCode: 0 } },
+      ],
+      onPath: ['demo'],
+    });
+    // list() observes the context signal it was handed; if the abort didn't
+    // propagate, ctx.signal.aborted would be false and this would resolve ok.
+    let sawAbort = false;
+    const plugin = fakePlugin('demo', ['demo'], async (ctx) => {
+      sawAbort = ctx.signal.aborted;
+      return [];
+    });
+    await checkPlugins(makeDeps({ exec, plugins: [plugin], signal: controller.signal }));
+    expect(sawAbort).toBe(true);
+  });
+});

--- a/apps/cli/test/integration/commands/doctor.test.ts
+++ b/apps/cli/test/integration/commands/doctor.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest';
+import { check as checkPlugins } from '../../../src/commands/doctor/checks/plugins';
+import type { CheckDeps } from '../../../src/commands/doctor/report';
+import { buildReport, exitCodeFor } from '../../../src/commands/doctor/report';
+import { ErrPluginUnavailable } from '../../../src/errors';
+import { FixtureExecRunner } from '../../../src/exec/fixtures';
+import type {
+  ListOptions,
+  PackageStatus,
+  Plugin,
+  PluginContext,
+  PluginManifest,
+} from '../../../src/plugins/types';
+
+const silentLog = { info() {}, warn() {}, error() {}, debug() {} };
+
+function fakePlugin(
+  id: string,
+  requires: string[],
+  list: (ctx: PluginContext, opts: ListOptions) => Promise<PackageStatus[]>,
+): Plugin {
+  const manifest: PluginManifest = {
+    id,
+    displayName: id,
+    supportedOS: ['darwin'],
+    requires,
+    configKeys: [],
+    capabilities: {
+      list: true,
+      install: false,
+      update: false,
+      add: false,
+      remove: false,
+      outdated: true,
+    },
+  };
+  return { manifest, list } as unknown as Plugin;
+}
+
+function makeDeps(overrides: Partial<CheckDeps>): CheckDeps {
+  return {
+    env: {},
+    home: '/home/test',
+    exec: new FixtureExecRunner({ fixtures: [], onPath: [] }),
+    log: silentLog,
+    signal: new AbortController().signal,
+    plugins: [],
+    paths: {
+      applistPath: '/tmp/applist.yaml',
+      configDir: '/tmp',
+      backupDir: '/tmp/backups',
+      source: 'home-macup',
+    },
+    platform: 'darwin',
+    arch: 'arm64',
+    osRelease: '25.2.0',
+    nodeVersion: 'v22.11.0',
+    macupVersion: '1.0.0',
+    probeTimeoutMs: 5_000,
+    ...overrides,
+  };
+}
+
+describe('doctor — plugins deep probe', () => {
+  it('a healthy plugin (binary on PATH, list succeeds) reports ok', async () => {
+    const exec = new FixtureExecRunner({
+      fixtures: [
+        {
+          cmd: 'demo',
+          args: ['--version'],
+          result: { stdout: 'demo 1.2.3', stderr: '', exitCode: 0 },
+        },
+      ],
+      onPath: ['demo'],
+    });
+    const plugin = fakePlugin('demo', ['demo'], async () => []);
+    const section = await checkPlugins(makeDeps({ exec, plugins: [plugin] }));
+    expect(section.results).toHaveLength(1);
+    expect(section.results[0]?.level).toBe('ok');
+    expect(section.results[0]?.detail).toContain('demo 1.2.3');
+  });
+
+  it('a missing binary is a warning, not an error (plugin simply disabled)', async () => {
+    const exec = new FixtureExecRunner({ fixtures: [], onPath: [] });
+    const plugin = fakePlugin('gone', ['gone'], async () => {
+      throw new Error('should not be probed when the binary is missing');
+    });
+    const section = await checkPlugins(makeDeps({ exec, plugins: [plugin] }));
+    expect(section.results[0]?.level).toBe('warn');
+    expect(section.results[0]?.detail).toContain('not on PATH');
+    expect(exitCodeFor(buildReport('1', [section]))).toBe(0);
+  });
+
+  it('ErrPluginUnavailable from list() is a warning', async () => {
+    const exec = new FixtureExecRunner({
+      fixtures: [
+        { cmd: 'demo', args: ['--version'], result: { stdout: 'demo 1', stderr: '', exitCode: 0 } },
+      ],
+      onPath: ['demo'],
+    });
+    const plugin = fakePlugin('demo', ['demo'], async () => {
+      throw new ErrPluginUnavailable('demo', 'backend went away');
+    });
+    const section = await checkPlugins(makeDeps({ exec, plugins: [plugin] }));
+    expect(section.results[0]?.level).toBe('warn');
+    expect(exitCodeFor(buildReport('1', [section]))).toBe(0);
+  });
+
+  it('a generic list() failure is an error and fails the exit code', async () => {
+    const exec = new FixtureExecRunner({
+      fixtures: [
+        { cmd: 'demo', args: ['--version'], result: { stdout: 'demo 1', stderr: '', exitCode: 0 } },
+      ],
+      onPath: ['demo'],
+    });
+    const plugin = fakePlugin('demo', ['demo'], async () => {
+      throw new Error('parse blew up');
+    });
+    const section = await checkPlugins(makeDeps({ exec, plugins: [plugin] }));
+    expect(section.results[0]?.level).toBe('error');
+    expect(section.results[0]?.detail).toContain('parse blew up');
+    expect(exitCodeFor(buildReport('1', [section]))).toBe(1);
+  });
+});

--- a/apps/cli/test/unit/commands/doctor-report.test.ts
+++ b/apps/cli/test/unit/commands/doctor-report.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest';
+import {
+  type CheckResult,
+  type Section,
+  buildReport,
+  exitCodeFor,
+  renderJson,
+  renderText,
+} from '../../../src/commands/doctor/report';
+
+function section(title: string, results: CheckResult[]): Section {
+  return { title, results };
+}
+
+describe('doctor report — buildReport summary', () => {
+  it('tallies ok / warn / error across every section', () => {
+    const report = buildReport('1.2.3', [
+      section('Environment', [
+        { level: 'ok', label: 'macOS' },
+        { level: 'ok', label: 'Node' },
+      ]),
+      section('Plugins', [
+        { level: 'warn', label: 'pnpm' },
+        { level: 'error', label: 'brew' },
+      ]),
+    ]);
+    expect(report.summary).toEqual({ ok: 2, warnings: 1, errors: 1 });
+    expect(report.version).toBe('1.2.3');
+  });
+
+  it('handles an empty section list', () => {
+    const report = buildReport('1.0.0', []);
+    expect(report.summary).toEqual({ ok: 0, warnings: 0, errors: 0 });
+  });
+});
+
+describe('doctor report — exitCodeFor', () => {
+  it('warnings never fail the exit (issue #42)', () => {
+    const report = buildReport('1', [
+      section('S', [
+        { level: 'ok', label: 'a' },
+        { level: 'warn', label: 'b' },
+        { level: 'warn', label: 'c' },
+      ]),
+    ]);
+    expect(exitCodeFor(report)).toBe(0);
+  });
+
+  it('any error fails the exit', () => {
+    const report = buildReport('1', [section('S', [{ level: 'error', label: 'a' }])]);
+    expect(exitCodeFor(report)).toBe(1);
+  });
+});
+
+describe('doctor report — renderText', () => {
+  it('renders section headers, detail, hints, and a summary line', () => {
+    const report = buildReport('1.0.0', [
+      section('Environment', [{ level: 'ok', label: 'macOS', detail: 'darwin 25.2.0 (arm64)' }]),
+      section('Plugins', [
+        { level: 'warn', label: 'pnpm', detail: 'not on PATH', hint: 'install pnpm' },
+      ]),
+    ]);
+    const text = renderText(report);
+    expect(text).toContain('ENVIRONMENT:');
+    expect(text).toContain('PLUGINS:');
+    expect(text).toContain('darwin 25.2.0 (arm64)');
+    expect(text).toContain('install pnpm');
+    expect(text).toContain('SUMMARY: 1 ok, 1 warning, 0 errors');
+  });
+
+  it('pluralises the summary counts correctly', () => {
+    const report = buildReport('1', [
+      section('S', [
+        { level: 'warn', label: 'a' },
+        { level: 'warn', label: 'b' },
+        { level: 'error', label: 'c' },
+        { level: 'error', label: 'd' },
+      ]),
+    ]);
+    expect(renderText(report)).toContain('SUMMARY: 0 ok, 2 warnings, 2 errors');
+  });
+});
+
+describe('doctor report — renderJson', () => {
+  it('round-trips to the report shape', () => {
+    const report = buildReport('9.9.9', [
+      section('Environment', [{ level: 'ok', label: 'Node', detail: 'v22' }]),
+    ]);
+    const parsed = JSON.parse(renderJson(report));
+    expect(parsed.version).toBe('9.9.9');
+    expect(parsed.summary).toEqual({ ok: 1, warnings: 0, errors: 0 });
+    expect(parsed.sections[0].results[0]).toEqual({ level: 'ok', label: 'Node', detail: 'v22' });
+  });
+});


### PR DESCRIPTION
Closes #42. Absorbs #11 (`macup info`).

Adds `macup --doctor`, a sectioned self-diagnostic, and `--doctor --json` for scripting/bug reports. Exit 0 when clean or warnings-only, 1 on any error — warnings never fail the exit.

## Sections
1. **Environment** — macOS/arch, shell, Node (error if < 20), macup version
2. **Config** — config dir writable, `applist.yaml` parses + validates (Zod error surfaced, not swallowed), backup dir count/size
3. **Plugins (deep)** — every built-in (not just registry-filtered): binary on PATH → version probe → an actual `plugin.list()` call under a 15s timeout. "Installed" ≠ "working"; a missing binary is a warning
4. **Data integrity (deep)** — per tracked package, resolves the name against the tool; flags stale pins/skips and tracked-but-not-installed
5. **Shell integration** — detects the shell, checks the completions path, prints the fix one-liner when missing

## Notes
- Refactors `isOnPath` → `pathTo` (resolved path) with a boolean wrapper, so plugin lines can show the binary location. Non-breaking.
- All subprocess work goes through `ExecRunner`; `ErrPluginUnavailable` is treated as a warning per the plugin contract.
- Verified live on macOS: renders all five sections, real probes, legacy-config migration warning, exit 0 on warnings.

## Tests
Unit tests for the report tallies/exit-codes/renderers; integration tests drive the deep probe against `FixtureExecRunner` for the healthy, missing-binary, unavailable, and hard-failure cases. `lint + typecheck + test` green (448).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
