### PR TITLE
feat(cli): add macup check + shell integration (#9, #24)

### DIFF
--- a/apps/cli/src/cli.ts
+++ b/apps/cli/src/cli.ts
@@ -25,10 +25,12 @@ import { extractVerbosityFlags, findUnknownTopLevelFlags, rewriteFlagAliases } f
 import { bootstrap } from './cli/bootstrap';
 import { printVersionSplash, showCustomHelp } from './cli/help';
 import type { FlagAction } from './cli/types';
+import { buildCheckCommand } from './commands/check';
 import { CleanupAction } from './commands/cleanup';
 import { CompletionsAction } from './commands/completions';
 import { ConfigAction } from './commands/config';
 import { commandsFromManifest } from './commands/from-manifest';
+import { buildInitCommand } from './commands/init';
 import { InstallCompletionsAction } from './commands/install-completions';
 import { LogoAction } from './commands/logo';
 import { buildOutdatedCommand } from './commands/outdated';
@@ -105,6 +107,8 @@ for (const plugin of deps.registry) {
 const topLevelSubCommands = {
   ...pluginSubCommands,
   outdated: buildOutdatedCommand(deps),
+  check: buildCheckCommand(deps),
+  init: buildInitCommand(),
 };
 
 // Startup: warn for plugins that can't load (missing binaries on the

--- a/apps/cli/src/cli/help.ts
+++ b/apps/cli/src/cli/help.ts
@@ -78,6 +78,12 @@ export function showCustomHelp(deps: CliDeps): void {
   console.log(
     `  ${s.bold('outdated'.padEnd(cmdPad))} Show outdated packages across every plugin in one pane  ${s.dim('[--json]')}`,
   );
+  console.log(
+    `  ${s.bold('check'.padEnd(cmdPad))} Exit 0 if everything is current, 1 if anything is outdated  ${s.dim('[--quiet]')}`,
+  );
+  console.log(
+    `  ${s.bold('init <shell>'.padEnd(cmdPad))} Emit shell integration (zsh|bash|fish) to eval from your rc file`,
+  );
   console.log(`  ${s.bold('version'.padEnd(cmdPad))} Show version with logo`);
   console.log(`  ${s.bold('help'.padEnd(cmdPad))} Show this help screen`);
   console.log(`  ${s.bold('config'.padEnd(cmdPad))} Show config path, schema, pins/skip counts`);

--- a/apps/cli/src/commands/check.ts
+++ b/apps/cli/src/commands/check.ts
@@ -1,11 +1,15 @@
 // `macup check` — health-check for shell prompts, cron, and CI gates.
 //
-// Exit 0 when nothing is outdated, 1 when anything is. Reuses the
-// outdated aggregation (buildOutdatedReport) rather than re-walking the
-// registry, so both commands always agree on what "outdated" means.
-// Output is a single plain line on stdout (no header, no spinner, no
-// ANSI) so `eval`/`$(...)` consumers — the `macup init` snippets — can
-// capture it verbatim. `--quiet` suppresses even that line.
+// Exit 0 only when everything is verified up to date; 1 when anything is
+// outdated OR a plugin couldn't be checked at all. A benign missing
+// backend (`ErrPluginUnavailable`) is ignored — you can't be outdated on a
+// tool you don't have — but a plugin whose check/list actually FAILED is
+// surfaced and fails the exit, so a CI gate never reports a clean bill of
+// health it couldn't verify. Reuses the outdated aggregation
+// (buildOutdatedReport) so check and outdated agree on "outdated".
+// Output is a single plain line on stdout (no header, spinner, or ANSI) so
+// `$(...)` consumers — the `macup init` snippets — capture it verbatim.
+// `--quiet` suppresses even that line.
 
 import { defineCommand } from 'citty';
 import type { CliDeps } from '../cli/types';
@@ -20,24 +24,34 @@ export const CHECK_ARGS = {
   },
 } as const;
 
+/** True when any plugin's check/list failed for a non-benign reason. */
+export function hasCheckFailure(report: OutdatedReport): boolean {
+  return report.plugins.some((p) => p.checkFailed);
+}
+
 /**
- * One-line summary: `3 brew, 1 npm outdated`, or `everything up to date`.
- * Unavailable plugins (missing binary) are omitted — a backend you don't
- * have can't be outdated, and a health check must not fail on it.
+ * One-line summary. Reports outdated counts (`3 brew, 1 npm outdated`) and
+ * any plugins that couldn't be checked (`npm check failed`), combined when
+ * both occur. `everything up to date` only when there's nothing of either.
  */
 export function formatCheckSummary(report: OutdatedReport): string {
-  if (report.totalOutdated === 0) return 'everything up to date';
-  const parts = report.plugins
+  const outdated = report.plugins
     .filter((p) => p.outdated.length > 0)
     .map((p) => `${p.outdated.length} ${p.pluginId}`);
-  return `${parts.join(', ')} outdated`;
+  const failed = report.plugins.filter((p) => p.checkFailed).map((p) => p.pluginId);
+
+  const segments: string[] = [];
+  if (outdated.length > 0) segments.push(`${outdated.join(', ')} outdated`);
+  if (failed.length > 0) segments.push(`${failed.join(', ')} check failed`);
+  return segments.length > 0 ? segments.join('; ') : 'everything up to date';
 }
 
 export function buildCheckCommand(deps: CliDeps) {
   return defineCommand({
     meta: {
       name: 'check',
-      description: 'Exit 0 when everything is up to date, 1 when anything is outdated.',
+      description:
+        'Exit 0 when everything is up to date, 1 when anything is outdated or uncheckable.',
     },
     args: CHECK_ARGS,
     async run({ args }) {
@@ -49,7 +63,7 @@ export function buildCheckCommand(deps: CliDeps) {
           signal: deps.signal,
         }),
       });
-      if (report.totalOutdated > 0) process.exitCode = 1;
+      if (report.totalOutdated > 0 || hasCheckFailure(report)) process.exitCode = 1;
       if (!args.quiet) console.log(formatCheckSummary(report));
     },
   });

--- a/apps/cli/src/commands/check.ts
+++ b/apps/cli/src/commands/check.ts
@@ -1,0 +1,56 @@
+// `macup check` — health-check for shell prompts, cron, and CI gates.
+//
+// Exit 0 when nothing is outdated, 1 when anything is. Reuses the
+// outdated aggregation (buildOutdatedReport) rather than re-walking the
+// registry, so both commands always agree on what "outdated" means.
+// Output is a single plain line on stdout (no header, no spinner, no
+// ANSI) so `eval`/`$(...)` consumers — the `macup init` snippets — can
+// capture it verbatim. `--quiet` suppresses even that line.
+
+import { defineCommand } from 'citty';
+import type { CliDeps } from '../cli/types';
+import { type OutdatedReport, buildOutdatedReport } from './outdated';
+
+// Arg defs live outside the factory so macup/meta can project them into
+// the generated reference without constructing CliDeps.
+export const CHECK_ARGS = {
+  quiet: {
+    type: 'boolean',
+    description: 'Print nothing; communicate through the exit code only.',
+  },
+} as const;
+
+/**
+ * One-line summary: `3 brew, 1 npm outdated`, or `everything up to date`.
+ * Unavailable plugins (missing binary) are omitted — a backend you don't
+ * have can't be outdated, and a health check must not fail on it.
+ */
+export function formatCheckSummary(report: OutdatedReport): string {
+  if (report.totalOutdated === 0) return 'everything up to date';
+  const parts = report.plugins
+    .filter((p) => p.outdated.length > 0)
+    .map((p) => `${p.outdated.length} ${p.pluginId}`);
+  return `${parts.join(', ')} outdated`;
+}
+
+export function buildCheckCommand(deps: CliDeps) {
+  return defineCommand({
+    meta: {
+      name: 'check',
+      description: 'Exit 0 when everything is up to date, 1 when anything is outdated.',
+    },
+    args: CHECK_ARGS,
+    async run({ args }) {
+      const report = await buildOutdatedReport({
+        plugins: deps.registry,
+        makeCtx: () => ({
+          exec: deps.exec,
+          log: deps.log,
+          signal: deps.signal,
+        }),
+      });
+      if (report.totalOutdated > 0) process.exitCode = 1;
+      if (!args.quiet) console.log(formatCheckSummary(report));
+    },
+  });
+}

--- a/apps/cli/src/commands/init.ts
+++ b/apps/cli/src/commands/init.ts
@@ -1,0 +1,138 @@
+// `macup init <shell>` — shell integration (zsh | bash | fish).
+//
+// Prints a snippet the user evals from their rc file:
+//
+//   eval "$(macup init zsh)"          # ~/.zshrc
+//   eval "$(macup init bash)"         # ~/.bashrc
+//   macup init fish | source          # ~/.config/fish/config.fish
+//
+// The snippet runs `macup check` in a disowned background job at most
+// once per session (guarded by exporting MACUP_CHECKED) and prints
+// `macup: <summary>` only when something is outdated. Invariants every
+// snippet must hold:
+//   - never blocks the prompt (background + disown),
+//   - never errors the shell (stderr swallowed, `command -v` guard,
+//     empty-summary guard so a crashed check prints nothing),
+//   - silent when everything is up to date.
+//
+// Namespace note: bare `macup init` (no shell) is reserved for the
+// config scaffolder (#14). That branch is isolated at the top of run()
+// so #14 can replace the placeholder error without touching the shell
+// dispatch below it.
+
+import { defineCommand } from 'citty';
+import { SUPPORTED_SHELLS, type Shell, isShell } from './shell';
+
+// Arg defs live outside the factory so macup/meta can project them into
+// the generated reference.
+export const INIT_ARGS = {
+  shell: {
+    type: 'positional',
+    required: false,
+    description: 'Shell to emit integration code for: zsh | bash | fish.',
+  },
+} as const;
+
+// `rc=$?` (not `status=$?`): $status is read-only in zsh and the
+// POSIX-ish body is shared between the zsh and bash snippets.
+const POSIX_NOTICE_FN = `_macup_check_notice() {
+  local summary rc
+  summary="$(command macup check 2>/dev/null)"
+  rc=$?
+  if [ "$rc" -eq 1 ] && [ -n "$summary" ]; then
+    printf 'macup: %s\\n' "$summary"
+  fi
+}`;
+
+function zshSnippet(): string {
+  // `&!` = background + disown in one token, so the job never surfaces
+  // in zsh's job table or prints a completion notice over the prompt.
+  return `# macup shell integration (zsh). Add to ~/.zshrc:
+#   eval "$(macup init zsh)"
+${POSIX_NOTICE_FN}
+if [ -z "\${MACUP_CHECKED:-}" ] && command -v macup >/dev/null 2>&1; then
+  export MACUP_CHECKED=1
+  _macup_check_notice &!
+fi
+`;
+}
+
+function bashSnippet(): string {
+  // disown drops the job from bash's table so no "[1]+ Done" notice
+  // lands over the prompt; `|| true` covers shells without job control.
+  return `# macup shell integration (bash). Add to ~/.bashrc:
+#   eval "$(macup init bash)"
+${POSIX_NOTICE_FN}
+if [ -z "\${MACUP_CHECKED:-}" ] && command -v macup >/dev/null 2>&1; then
+  export MACUP_CHECKED=1
+  _macup_check_notice &
+  disown 2>/dev/null || true
+fi
+`;
+}
+
+function fishSnippet(): string {
+  // `set -l summary (...)` passes the substitution's $status through on
+  // fish >= 3.4; on older fish $status is 0 and the snippet fails safe
+  // (silent). set -gx exports the guard to child sessions, matching the
+  // zsh/bash `export`.
+  return `# macup shell integration (fish). Add to ~/.config/fish/config.fish:
+#   macup init fish | source
+function _macup_check_notice
+    set -l summary (command macup check 2>/dev/null)
+    set -l rc $status
+    if test "$rc" -eq 1; and test -n "$summary"
+        echo "macup: $summary"
+    end
+end
+if not set -q MACUP_CHECKED; and command -sq macup
+    set -gx MACUP_CHECKED 1
+    _macup_check_notice &
+    disown 2>/dev/null
+end
+`;
+}
+
+export function renderInitSnippet(shell: Shell): string {
+  switch (shell) {
+    case 'zsh':
+      return zshSnippet();
+    case 'bash':
+      return bashSnippet();
+    case 'fish':
+      return fishSnippet();
+  }
+}
+
+export function buildInitCommand() {
+  return defineCommand({
+    meta: {
+      name: 'init',
+      description: 'Emit shell integration code (zsh | bash | fish) to eval from your rc file.',
+    },
+    args: INIT_ARGS,
+    async run({ args }) {
+      const shellArg = args.shell as string | undefined;
+
+      // Reserved namespace (#14): bare `macup init` will scaffold the
+      // config file. Until that lands, point at the shell form.
+      if (!shellArg) {
+        console.error('error: missing <shell> argument');
+        console.error('usage: macup init <zsh|bash|fish>, e.g. eval "$(macup init zsh)"');
+        console.error('(bare `macup init` is reserved for the upcoming config scaffolder)');
+        process.exitCode = 1;
+        return;
+      }
+
+      if (!isShell(shellArg)) {
+        console.error(
+          `error: unknown shell "${shellArg}" (expected ${SUPPORTED_SHELLS.join(', ')})`,
+        );
+        process.exitCode = 1;
+        return;
+      }
+
+      process.stdout.write(renderInitSnippet(shellArg));
+    },
+  });
+}

--- a/apps/cli/src/commands/outdated.ts
+++ b/apps/cli/src/commands/outdated.ts
@@ -1,6 +1,7 @@
 import { spinner } from '@clack/prompts';
 import { defineCommand } from 'citty';
 import type { CliDeps } from '../cli/types';
+import { ErrPluginUnavailable } from '../errors';
 import type { PackageStatus, Plugin, PluginContext } from '../plugins/types';
 
 export interface OutdatedPluginSummary {
@@ -10,6 +11,14 @@ export interface OutdatedPluginSummary {
   available: boolean;
   /** Short reason string when `available` is false. */
   reason?: string;
+  /**
+   * True when `available` is false for an UNEXPECTED reason — the plugin's
+   * check/list threw something other than `ErrPluginUnavailable`. A benign
+   * missing backend (`ErrPluginUnavailable`) leaves this false; a real
+   * failure to determine state sets it, so callers like `macup check` can
+   * refuse to report a clean bill of health they couldn't actually verify.
+   */
+  checkFailed: boolean;
   /** Outdated packages reported by the plugin (empty when up-to-date). */
   outdated: readonly PackageStatus[];
 }
@@ -65,6 +74,7 @@ export async function buildOutdatedReport(deps: OutdatedReportDeps): Promise<Out
           pluginId: plugin.manifest.id,
           displayName: plugin.manifest.displayName,
           available: true,
+          checkFailed: false,
           outdated,
         };
       } catch (err) {
@@ -73,6 +83,7 @@ export async function buildOutdatedReport(deps: OutdatedReportDeps): Promise<Out
           displayName: plugin.manifest.displayName,
           available: false,
           reason: err instanceof Error ? err.message : String(err),
+          checkFailed: !(err instanceof ErrPluginUnavailable),
           outdated: [],
         };
       } finally {

--- a/apps/cli/src/meta.ts
+++ b/apps/cli/src/meta.ts
@@ -12,6 +12,7 @@
 // apps/docs/scripts/generate-reference.ts.
 
 import { FLAG_COMMAND_ALIASES } from './cli/argv';
+import { CHECK_ARGS } from './commands/check';
 import { OUTDATED_ARGS } from './commands/outdated';
 import { SUBTYPE_COMMANDS, commandsFor, flagsForCommand } from './completions/shared';
 import { ApplistKeySchema } from './config/schema';
@@ -233,6 +234,20 @@ export function docsMetadata(): DocsMetadata {
           flag: `--${name}`,
           description: FLAG_DESCRIPTIONS[`--${name}`] ?? def.description,
         })),
+      },
+      {
+        name: 'check',
+        flags: Object.entries(CHECK_ARGS).map(([name, def]) => ({
+          flag: `--${name}`,
+          description: FLAG_DESCRIPTIONS[`--${name}`] ?? def.description,
+        })),
+      },
+      {
+        // `init` takes a positional (<shell>), not flags. Empty flags
+        // keeps it out of the docs flag matrix (flagless rows drop);
+        // INIT_ARGS.shell.description stays the prose source of truth.
+        name: 'init',
+        flags: [],
       },
     ],
     globalFlags: GLOBAL_FLAGS.map((f) => ({ ...f, bareForm: bareFormFor(f.flag) })),

--- a/apps/cli/test/integration/commands/__snapshots__/init.test.ts.snap
+++ b/apps/cli/test/integration/commands/__snapshots__/init.test.ts.snap
@@ -1,0 +1,56 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`renderInitSnippet — per-shell snapshots > bash snippet matches its snapshot 1`] = `
+"# macup shell integration (bash). Add to ~/.bashrc:
+#   eval "$(macup init bash)"
+_macup_check_notice() {
+  local summary rc
+  summary="$(command macup check 2>/dev/null)"
+  rc=$?
+  if [ "$rc" -eq 1 ] && [ -n "$summary" ]; then
+    printf 'macup: %s\\n' "$summary"
+  fi
+}
+if [ -z "\${MACUP_CHECKED:-}" ] && command -v macup >/dev/null 2>&1; then
+  export MACUP_CHECKED=1
+  _macup_check_notice &
+  disown 2>/dev/null || true
+fi
+"
+`;
+
+exports[`renderInitSnippet — per-shell snapshots > fish snippet matches its snapshot 1`] = `
+"# macup shell integration (fish). Add to ~/.config/fish/config.fish:
+#   macup init fish | source
+function _macup_check_notice
+    set -l summary (command macup check 2>/dev/null)
+    set -l rc $status
+    if test "$rc" -eq 1; and test -n "$summary"
+        echo "macup: $summary"
+    end
+end
+if not set -q MACUP_CHECKED; and command -sq macup
+    set -gx MACUP_CHECKED 1
+    _macup_check_notice &
+    disown 2>/dev/null
+end
+"
+`;
+
+exports[`renderInitSnippet — per-shell snapshots > zsh snippet matches its snapshot 1`] = `
+"# macup shell integration (zsh). Add to ~/.zshrc:
+#   eval "$(macup init zsh)"
+_macup_check_notice() {
+  local summary rc
+  summary="$(command macup check 2>/dev/null)"
+  rc=$?
+  if [ "$rc" -eq 1 ] && [ -n "$summary" ]; then
+    printf 'macup: %s\\n' "$summary"
+  fi
+}
+if [ -z "\${MACUP_CHECKED:-}" ] && command -v macup >/dev/null 2>&1; then
+  export MACUP_CHECKED=1
+  _macup_check_notice &!
+fi
+"
+`;

--- a/apps/cli/test/integration/commands/check.test.ts
+++ b/apps/cli/test/integration/commands/check.test.ts
@@ -1,0 +1,98 @@
+// `macup check` against the real npm plugin driven by FixtureExecRunner —
+// no live subprocess. Covers the exit-code contract (#9): 0 when clean,
+// 1 when anything is outdated, and `--quiet` printing nothing either way.
+
+import { join } from 'node:path';
+import { type CommandDef, runCommand } from 'citty';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import npmPlugin from '../../../plugins/npm';
+import type { CliDeps } from '../../../src/cli/types';
+import { buildCheckCommand } from '../../../src/commands/check';
+import { type FixtureEntry, FixtureExecRunner, loadFixtures } from '../../../src/exec/fixtures';
+import type { ExecRunner } from '../../../src/plugins/types';
+
+// The committed npm recording reports eslint + typescript outdated (2).
+const OUTDATED_FIXTURE_PATH = join(__dirname, '../../fixtures/recordings/npm.json');
+
+// A clean machine: one global package, `npm outdated` reports nothing.
+const CLEAN_FIXTURES: FixtureEntry[] = [
+  {
+    cmd: 'npm',
+    args: ['list', '-g', '--json'],
+    result: {
+      stdout: '{"dependencies":{"typescript":{"version":"5.4.0"}}}',
+      stderr: '',
+      exitCode: 0,
+    },
+  },
+  {
+    cmd: 'npm',
+    args: ['outdated', '-g', '--json'],
+    result: { stdout: '{}', stderr: '', exitCode: 0 },
+  },
+];
+
+function mkDeps(exec: ExecRunner): CliDeps {
+  return {
+    exec,
+    log: { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} },
+    registry: [npmPlugin],
+    signal: new AbortController().signal,
+  } as unknown as CliDeps;
+}
+
+async function runCheck(exec: ExecRunner, rawArgs: string[] = []): Promise<void> {
+  await runCommand(buildCheckCommand(mkDeps(exec)) as CommandDef, { rawArgs });
+}
+
+describe('macup check — exit code and summary (#9)', () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  const savedExitCode = process.exitCode;
+
+  beforeEach(() => {
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    // Restore so a check-set exitCode=1 can't fail the vitest process.
+    process.exitCode = savedExitCode;
+    vi.restoreAllMocks();
+  });
+
+  it('exits 1 and prints a one-line summary when packages are outdated', async () => {
+    const fixtures = await loadFixtures(OUTDATED_FIXTURE_PATH);
+    await runCheck(new FixtureExecRunner({ fixtures, onPath: ['npm'] }));
+    expect(process.exitCode).toBe(1);
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    expect(logSpy).toHaveBeenCalledWith('2 npm outdated');
+  });
+
+  it('exits 0 and reports up-to-date when nothing is outdated', async () => {
+    await runCheck(new FixtureExecRunner({ fixtures: CLEAN_FIXTURES, onPath: ['npm'] }));
+    expect(process.exitCode).toBe(savedExitCode);
+    expect(logSpy).toHaveBeenCalledWith('everything up to date');
+  });
+
+  it('--quiet prints nothing but still exits 1 when outdated', async () => {
+    const fixtures = await loadFixtures(OUTDATED_FIXTURE_PATH);
+    await runCheck(new FixtureExecRunner({ fixtures, onPath: ['npm'] }), ['--quiet']);
+    expect(process.exitCode).toBe(1);
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+
+  it('--quiet prints nothing and exits 0 when clean', async () => {
+    await runCheck(new FixtureExecRunner({ fixtures: CLEAN_FIXTURES, onPath: ['npm'] }), [
+      '--quiet',
+    ]);
+    expect(process.exitCode).toBe(savedExitCode);
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+
+  it('treats an unavailable backend as clean, not as a failure', async () => {
+    // npm missing from PATH → plugin check() throws ErrPluginUnavailable;
+    // a backend you don't have can't be outdated.
+    await runCheck(new FixtureExecRunner({ fixtures: [], onPath: [] }));
+    expect(process.exitCode).toBe(savedExitCode);
+    expect(logSpy).toHaveBeenCalledWith('everything up to date');
+  });
+});

--- a/apps/cli/test/integration/commands/check.test.ts
+++ b/apps/cli/test/integration/commands/check.test.ts
@@ -95,4 +95,13 @@ describe('macup check — exit code and summary (#9)', () => {
     expect(process.exitCode).toBe(savedExitCode);
     expect(logSpy).toHaveBeenCalledWith('everything up to date');
   });
+
+  it('exits 1 and reports the failure when a plugin cannot be checked', async () => {
+    // npm IS on PATH (check() passes) but no fixture covers `npm list` — so
+    // list() throws a real, non-ErrPluginUnavailable error. A CI gate must
+    // not report green when it couldn't actually verify a backend.
+    await runCheck(new FixtureExecRunner({ fixtures: [], onPath: ['npm'] }));
+    expect(process.exitCode).toBe(1);
+    expect(logSpy).toHaveBeenCalledWith('npm check failed');
+  });
 });

--- a/apps/cli/test/integration/commands/init.test.ts
+++ b/apps/cli/test/integration/commands/init.test.ts
@@ -1,0 +1,91 @@
+// `macup init <shell>` (#24) — emitted snippets are snapshotted per
+// shell so any change to what users eval from their rc files shows up
+// in review. The bash-family snippet is additionally shellcheck-linted
+// when shellcheck is installed (same tool the repo's `pnpm shellcheck`
+// script uses); zsh and fish are dialects shellcheck cannot parse.
+
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { type CommandDef, runCommand } from 'citty';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { buildInitCommand, renderInitSnippet } from '../../../src/commands/init';
+import { SUPPORTED_SHELLS } from '../../../src/commands/shell';
+
+async function runInit(rawArgs: string[]): Promise<void> {
+  await runCommand(buildInitCommand() as CommandDef, { rawArgs });
+}
+
+const savedExitCode = process.exitCode;
+afterEach(() => {
+  process.exitCode = savedExitCode;
+  vi.restoreAllMocks();
+});
+
+describe('renderInitSnippet — per-shell snapshots', () => {
+  it.each(SUPPORTED_SHELLS)('%s snippet matches its snapshot', (shell) => {
+    expect(renderInitSnippet(shell)).toMatchSnapshot();
+  });
+
+  it.each(SUPPORTED_SHELLS)('%s snippet holds the shared invariants', (shell) => {
+    const out = renderInitSnippet(shell);
+    // Once-per-session guard, exported so child shells inherit it.
+    expect(out).toContain('MACUP_CHECKED');
+    // Delegates to `macup check`; stderr swallowed so a broken install
+    // can never error the shell.
+    expect(out).toContain('macup check 2>/dev/null');
+    // Backgrounded so the prompt is never blocked.
+    expect(out).toMatch(/&!?$/m);
+    expect(out.endsWith('\n')).toBe(true);
+  });
+});
+
+describe('macup init — argument handling', () => {
+  it('writes the snippet to stdout for a valid shell', async () => {
+    const writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    await runInit(['zsh']);
+    expect(process.exitCode).toBe(savedExitCode);
+    expect(writeSpy).toHaveBeenCalledWith(renderInitSnippet('zsh'));
+  });
+
+  it('bare `macup init` errors with a hint at `init <shell>` (reserved for #14)', async () => {
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    await runInit([]);
+    expect(process.exitCode).toBe(1);
+    const stderr = errSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(stderr).toContain('macup init <zsh|bash|fish>');
+    expect(stderr).toContain('config scaffolder');
+  });
+
+  it('rejects an unsupported shell with exit code 1', async () => {
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    await runInit(['tcsh']);
+    expect(process.exitCode).toBe(1);
+    const stderr = errSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(stderr).toContain('unknown shell "tcsh"');
+    expect(stderr).toContain('zsh, bash, fish');
+  });
+});
+
+const hasShellcheck = (() => {
+  try {
+    execFileSync('shellcheck', ['--version'], { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+})();
+
+describe('emitted snippet — shellcheck', () => {
+  it.skipIf(!hasShellcheck)('bash snippet passes shellcheck --severity=warning', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'macup-init-'));
+    const file = join(dir, 'init-bash.sh');
+    writeFileSync(file, renderInitSnippet('bash'));
+    // Throws (fails the test) on findings; matches the severity the
+    // repo-root `pnpm shellcheck` script gates on.
+    execFileSync('shellcheck', ['--shell=bash', '--severity=warning', file], {
+      stdio: 'pipe',
+    });
+  });
+});

--- a/apps/cli/test/unit/commands/check.test.ts
+++ b/apps/cli/test/unit/commands/check.test.ts
@@ -1,14 +1,15 @@
 import { describe, expect, it } from 'vitest';
-import { formatCheckSummary } from '../../../src/commands/check';
+import { formatCheckSummary, hasCheckFailure } from '../../../src/commands/check';
 import type { OutdatedReport } from '../../../src/commands/outdated';
 
 function report(
-  perPlugin: Array<{ id: string; count: number; available?: boolean }>,
+  perPlugin: Array<{ id: string; count: number; available?: boolean; checkFailed?: boolean }>,
 ): OutdatedReport {
-  const plugins = perPlugin.map(({ id, count, available }) => ({
+  const plugins = perPlugin.map(({ id, count, available, checkFailed }) => ({
     pluginId: id,
     displayName: id.toUpperCase(),
     available: available ?? true,
+    checkFailed: checkFailed ?? false,
     outdated: Array.from({ length: count }, (_, i) => ({
       ref: { kind: id, name: `pkg-${i}` },
       installed: true,
@@ -46,8 +47,24 @@ describe('formatCheckSummary', () => {
     expect(out).toBe('everything up to date');
   });
 
-  it('treats an unavailable plugin as up to date, not as a failure', () => {
-    const out = formatCheckSummary(report([{ id: 'mas', count: 0, available: false }]));
-    expect(out).toBe('everything up to date');
+  it('treats a benignly-unavailable plugin as up to date, not as a failure', () => {
+    const r = report([{ id: 'mas', count: 0, available: false }]);
+    expect(formatCheckSummary(r)).toBe('everything up to date');
+    expect(hasCheckFailure(r)).toBe(false);
+  });
+
+  it('surfaces a plugin whose check failed, even with nothing outdated', () => {
+    const r = report([{ id: 'npm', count: 0, available: false, checkFailed: true }]);
+    expect(formatCheckSummary(r)).toBe('npm check failed');
+    expect(hasCheckFailure(r)).toBe(true);
+  });
+
+  it('combines outdated counts and check failures in one line', () => {
+    const r = report([
+      { id: 'brew', count: 2 },
+      { id: 'npm', count: 0, available: false, checkFailed: true },
+    ]);
+    expect(formatCheckSummary(r)).toBe('2 brew outdated; npm check failed');
+    expect(hasCheckFailure(r)).toBe(true);
   });
 });

--- a/apps/cli/test/unit/commands/check.test.ts
+++ b/apps/cli/test/unit/commands/check.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { formatCheckSummary } from '../../../src/commands/check';
+import type { OutdatedReport } from '../../../src/commands/outdated';
+
+function report(perPlugin: Array<{ id: string; count: number; available?: boolean }>): OutdatedReport {
+  const plugins = perPlugin.map(({ id, count, available }) => ({
+    pluginId: id,
+    displayName: id.toUpperCase(),
+    available: available ?? true,
+    outdated: Array.from({ length: count }, (_, i) => ({
+      ref: { kind: id, name: `pkg-${i}` },
+      installed: true,
+      installedVersion: '1',
+      latestVersion: '2',
+      outdated: true,
+    })),
+  }));
+  return { plugins, totalOutdated: plugins.reduce((s, p) => s + p.outdated.length, 0) };
+}
+
+describe('formatCheckSummary', () => {
+  it('renders per-plugin counts in registry order: `3 brew, 1 npm outdated`', () => {
+    const out = formatCheckSummary(
+      report([
+        { id: 'brew', count: 3 },
+        { id: 'npm', count: 1 },
+      ]),
+    );
+    expect(out).toBe('3 brew, 1 npm outdated');
+  });
+
+  it('omits up-to-date plugins from the summary', () => {
+    const out = formatCheckSummary(
+      report([
+        { id: 'brew', count: 0 },
+        { id: 'npm', count: 2 },
+      ]),
+    );
+    expect(out).toBe('2 npm outdated');
+  });
+
+  it('reports `everything up to date` when nothing is outdated', () => {
+    const out = formatCheckSummary(report([{ id: 'brew', count: 0 }]));
+    expect(out).toBe('everything up to date');
+  });
+
+  it('treats an unavailable plugin as up to date, not as a failure', () => {
+    const out = formatCheckSummary(report([{ id: 'mas', count: 0, available: false }]));
+    expect(out).toBe('everything up to date');
+  });
+});

--- a/apps/cli/test/unit/commands/check.test.ts
+++ b/apps/cli/test/unit/commands/check.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from 'vitest';
 import { formatCheckSummary } from '../../../src/commands/check';
 import type { OutdatedReport } from '../../../src/commands/outdated';
 
-function report(perPlugin: Array<{ id: string; count: number; available?: boolean }>): OutdatedReport {
+function report(
+  perPlugin: Array<{ id: string; count: number; available?: boolean }>,
+): OutdatedReport {
   const plugins = perPlugin.map(({ id, count, available }) => ({
     pluginId: id,
     displayName: id.toUpperCase(),

--- a/apps/cli/test/unit/outdated.test.ts
+++ b/apps/cli/test/unit/outdated.test.ts
@@ -116,6 +116,7 @@ describe('formatOutdatedReport', () => {
       pluginId: id,
       displayName: id.toUpperCase(),
       available: true,
+      checkFailed: false,
       outdated: names.map((name) => ({
         ref: { kind: id, name },
         installed: true,
@@ -177,6 +178,7 @@ describe('formatOutdatedReport', () => {
           displayName: 'Mac App Store',
           available: false,
           reason: '`mas` was not found on PATH',
+          checkFailed: false,
           outdated: [],
         },
       ],

--- a/apps/docs/scripts/generate-reference.ts
+++ b/apps/docs/scripts/generate-reference.ts
@@ -86,7 +86,7 @@ function flagAvailability(meta: DocsMetadata): string {
     const cells = flags.map((f) => (accept.get(f)?.has(cmd) ? 'yes' : ' '));
     out += `| \`${cmd}\` | ${cells.join(' | ')} |\n`;
   }
-  out += '\n`outdated` and `check` are top-level (`macup outdated`); the rest are per-plugin ';
+  out += '\n`outdated` and `check` are top-level (`macup outdated`, `macup check`); the rest are per-plugin ';
   out += '(`macup brew list`). `--cask`, `--formula`, and `--subtype` are Homebrew only.\n';
   return out;
 }

--- a/apps/docs/scripts/generate-reference.ts
+++ b/apps/docs/scripts/generate-reference.ts
@@ -86,7 +86,7 @@ function flagAvailability(meta: DocsMetadata): string {
     const cells = flags.map((f) => (accept.get(f)?.has(cmd) ? 'yes' : ' '));
     out += `| \`${cmd}\` | ${cells.join(' | ')} |\n`;
   }
-  out += '\n`outdated` is top-level (`macup outdated`); the rest are per-plugin ';
+  out += '\n`outdated` and `check` are top-level (`macup outdated`); the rest are per-plugin ';
   out += '(`macup brew list`). `--cask`, `--formula`, and `--subtype` are Homebrew only.\n';
   return out;
 }


### PR DESCRIPTION
Closes #9 and #24 (#24 depends on #9, so they ship together).

## `macup check` (#9)
Exit 0 only when everything is verified up to date; 1 when anything is outdated **or** a plugin couldn't be checked. `--quiet` communicates through the exit code only; otherwise a one-line summary (`3 brew, 1 npm outdated`). Reuses `buildOutdatedReport`, so `check` and `outdated` can't disagree on what "outdated" means. A benign missing backend (`ErrPluginUnavailable`) is ignored; a real check/list failure is surfaced (`npm check failed`) and fails the exit — a CI gate never reports a clean bill of health it couldn't confirm.

## `macup init <shell>` (#24)
Emits zsh/bash/fish integration to eval from an rc file. The snippet runs `macup check` once per session (guarded by `MACUP_CHECKED`), captures its stdout summary, and prints `macup: <summary>` only when `check` exits non-zero — never blocks or errors the shell (backgrounded + disowned, stderr swallowed). It runs plain `macup check` (not `--quiet`) precisely because it needs that summary line. Bare `macup init` is reserved for the config scaffolder (#14) and prints a helpful pointer for now.

## Notes
- Wired as top-level commands + help + completions.
- Per-shell snippets snapshot-tested (zsh `&!`, bash/fish `disown`, fish `$status` handling).

## Review fixes (Copilot)
- `check` no longer false-greens when a plugin errors (distinguishes `ErrPluginUnavailable` from real failures).
- Corrected the `check.ts` doc comment and the generate-reference top-level-commands example.
- Corrected this description: the snippet runs `macup check`, not `--quiet`.

## Tests
`lint + typecheck + test` green (459).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
