### PR TITLE
feat(config): add applist schema version field (#7)

### DIFF
--- a/apps/cli/src/commands/config.ts
+++ b/apps/cli/src/commands/config.ts
@@ -11,6 +11,8 @@ export interface ConfigReport {
   exists: boolean;
   schemaValid: boolean;
   schemaError?: string;
+  /** Declared or defaulted schema version; undefined when the file is absent or invalid. */
+  schemaVersion?: number;
   pinsCount: number;
   skipCount: number;
   backupDir: string;
@@ -47,6 +49,7 @@ export async function buildConfigReport(paths: PathResolution): Promise<ConfigRe
         .join('; ');
     } else {
       report.schemaValid = true;
+      report.schemaVersion = result.data.version;
       report.pinsCount = Object.values(result.data.pins).reduce(
         (acc, pluginPins) => acc + Object.keys(pluginPins).length,
         0,
@@ -69,7 +72,7 @@ export function formatConfigReport(report: ConfigReport): string {
     `applist:     ${report.applistPath}`,
     `source:      ${report.source}`,
     `exists:      ${report.exists ? 'yes' : 'no (will be created on first write)'}`,
-    `schema:      ${report.schemaValid ? 'valid' : `INVALID — ${report.schemaError ?? 'unknown'}`}`,
+    `schema:      ${report.schemaValid ? `valid${report.schemaVersion ? ` (v${report.schemaVersion})` : ''}` : `INVALID — ${report.schemaError ?? 'unknown'}`}`,
     `pins:        ${report.pinsCount}`,
     `skip:        ${report.skipCount}`,
     `backups dir: ${report.backupDir}`,

--- a/apps/cli/src/commands/config.ts
+++ b/apps/cli/src/commands/config.ts
@@ -3,7 +3,7 @@ import { readFile } from 'node:fs/promises';
 import { parse } from 'yaml';
 import type { CliDeps, FlagAction, ParsedArgs } from '../cli/types';
 import type { PathResolution } from '../config/paths';
-import { ApplistSchema } from '../config/schema';
+import { ApplistSchema, SCHEMA_VERSION } from '../config/schema';
 
 export interface ConfigReport {
   applistPath: string;
@@ -47,6 +47,13 @@ export async function buildConfigReport(paths: PathResolution): Promise<ConfigRe
       report.schemaError = result.error.issues
         .map((i) => `${i.path.join('.')}: ${i.message}`)
         .join('; ');
+    } else if (result.data.version > SCHEMA_VERSION) {
+      // Mirror the store's load-time rejection: a newer-than-supported
+      // version is not something this build can safely read, so `--config`
+      // must not call it valid.
+      report.schemaValid = false;
+      report.schemaVersion = result.data.version;
+      report.schemaError = `schema version ${result.data.version} is newer than this macup supports (${SCHEMA_VERSION}) — upgrade macup`;
     } else {
       report.schemaValid = true;
       report.schemaVersion = result.data.version;

--- a/apps/cli/src/config/schema.ts
+++ b/apps/cli/src/config/schema.ts
@@ -1,11 +1,18 @@
 import { z } from 'zod';
 
 // The applist schema version this build reads and writes. Bump only on a
-// breaking shape change, and add a migration in the store's load path.
-// Files without a `version:` field are read as SCHEMA_VERSION (a v1 file
-// predates the field); a file declaring a HIGHER version than this is
-// rejected at load — it was written by a newer macup. See ADR/issue #7.
+// breaking shape change, and add a migration in the store's load path. A
+// file declaring a HIGHER version is rejected at load — it was written by
+// a newer macup. See ADR/issue #7.
 export const SCHEMA_VERSION = 1;
+
+// The version at which the `version:` field was introduced. A file with no
+// `version:` predates the field and is therefore exactly this version — so
+// the schema default is this literal, NOT SCHEMA_VERSION. Keeping them
+// separate means a future SCHEMA_VERSION bump won't silently reinterpret a
+// legacy version-less file as the new schema; it stays v1 until an explicit
+// migration upgrades it.
+export const INITIAL_SCHEMA_VERSION = 1;
 
 // ApplistKey identifies a list of tracked package names within applist.yaml.
 // Keys are dotted paths matching the in-file structure: top-level lists use
@@ -24,10 +31,11 @@ export const BrewListSchema = z
   .default({ formulas: [], casks: [] });
 
 export const ApplistSchema = z.object({
-  // Absent in v1 files (the field postdates them), so it defaults rather
-  // than being required. Load-time logic rejects versions above what this
-  // build knows; zod only guarantees it's a positive integer.
-  version: z.number().int().positive().default(SCHEMA_VERSION),
+  // Absent in v1 files (the field postdates them), so it defaults to the
+  // introduction version rather than being required. Load-time logic
+  // rejects versions above what this build knows; zod only guarantees a
+  // positive integer.
+  version: z.number().int().positive().default(INITIAL_SCHEMA_VERSION),
   appstore: StringList,
   npm: StringList,
   pnpm: StringList,

--- a/apps/cli/src/config/schema.ts
+++ b/apps/cli/src/config/schema.ts
@@ -1,5 +1,12 @@
 import { z } from 'zod';
 
+// The applist schema version this build reads and writes. Bump only on a
+// breaking shape change, and add a migration in the store's load path.
+// Files without a `version:` field are read as SCHEMA_VERSION (a v1 file
+// predates the field); a file declaring a HIGHER version than this is
+// rejected at load — it was written by a newer macup. See ADR/issue #7.
+export const SCHEMA_VERSION = 1;
+
 // ApplistKey identifies a list of tracked package names within applist.yaml.
 // Keys are dotted paths matching the in-file structure: top-level lists use
 // a single segment ('npm') and lists nested under a plugin block use two
@@ -17,6 +24,10 @@ export const BrewListSchema = z
   .default({ formulas: [], casks: [] });
 
 export const ApplistSchema = z.object({
+  // Absent in v1 files (the field postdates them), so it defaults rather
+  // than being required. Load-time logic rejects versions above what this
+  // build knows; zod only guarantees it's a positive integer.
+  version: z.number().int().positive().default(SCHEMA_VERSION),
   appstore: StringList,
   npm: StringList,
   pnpm: StringList,

--- a/apps/cli/src/config/store.ts
+++ b/apps/cli/src/config/store.ts
@@ -4,7 +4,7 @@ import { join } from 'node:path';
 import { type Document, Scalar, YAMLMap, YAMLSeq, parseDocument } from 'yaml';
 import { ErrInvalidConfig } from '../errors';
 import type { SelectionPolicy } from '../plugins/selection';
-import { type ApplistKey, ApplistSchema } from './schema';
+import { type ApplistKey, ApplistSchema, SCHEMA_VERSION } from './schema';
 
 export interface ConfigStorePaths {
   readonly applistPath: string;
@@ -104,6 +104,17 @@ function migrateInPlace(doc: Document): boolean {
   return migrated;
 }
 
+// Insert `version: SCHEMA_VERSION` at the top of the map when absent, so
+// the field leads the file the way readers expect. Mutates in memory
+// only; the caller decides whether that reaches disk. Returns whether it
+// changed anything.
+function stampVersion(doc: Document): boolean {
+  if (!(doc.contents instanceof YAMLMap)) return false;
+  if (doc.contents.has('version')) return false;
+  doc.contents.items.unshift(doc.createPair('version', SCHEMA_VERSION));
+  return true;
+}
+
 function pathFor(key: ApplistKey): readonly string[] {
   return key.split('.');
 }
@@ -172,6 +183,15 @@ export class ConfigStore {
     this.originalText = text;
     this.doc = parseDocument(text);
 
+    // Stamp the schema version before migrating so a legacy-key migration
+    // persists a versioned file in the same write. On a file that only
+    // lacks `version` (nothing else to migrate), this is an in-memory
+    // change that does NOT force a rewrite — the field lands the next time
+    // the user actually mutates config, keeping read-only commands
+    // side-effect free. The load-time no-change guard is baselined below
+    // AFTER this stamp, so save() sees a version-only file as unchanged.
+    stampVersion(this.doc);
+
     let result: LoadResult = { migrated: false };
     if (migrateInPlace(this.doc)) {
       const backupPath = await this.persistMigration();
@@ -197,6 +217,16 @@ export class ConfigStore {
         ? ` (auto-migration ran; original saved to ${result.migrationBackupPath})`
         : '';
       throw new ErrInvalidConfig(this.paths.applistPath, parsed.error.message + suffix);
+    }
+
+    // A file declaring a higher version was written by a newer macup whose
+    // shape this build may not understand. Refuse rather than silently
+    // misread it — that's the whole point of the version field.
+    if (parsed.data.version > SCHEMA_VERSION) {
+      throw new ErrInvalidConfig(
+        this.paths.applistPath,
+        `schema version ${parsed.data.version} is newer than this macup supports (${SCHEMA_VERSION}) — upgrade macup`,
+      );
     }
     return result;
   }
@@ -359,6 +389,13 @@ export class ConfigStore {
 
   async save(operation: string): Promise<SaveResult> {
     const doc = this.requireDoc();
+    // Stamp version here too, not only in load(): a brand-new config has
+    // no YAMLMap to stamp at load time (the doc gains contents only when
+    // the first key is added), so this is where a first-run file earns its
+    // version field. On a loaded file it's a no-op — load() already
+    // stamped and baselined originalText with the field, so the no-change
+    // guard below still sees a version-only file as unchanged.
+    stampVersion(doc);
     const newText = doc.toString();
     if (newText === this.originalText) {
       return { changed: false };

--- a/apps/cli/src/config/store.ts
+++ b/apps/cli/src/config/store.ts
@@ -4,7 +4,7 @@ import { join } from 'node:path';
 import { type Document, Scalar, YAMLMap, YAMLSeq, parseDocument } from 'yaml';
 import { ErrInvalidConfig } from '../errors';
 import type { SelectionPolicy } from '../plugins/selection';
-import { type ApplistKey, ApplistSchema, SCHEMA_VERSION } from './schema';
+import { type ApplistKey, ApplistSchema, INITIAL_SCHEMA_VERSION, SCHEMA_VERSION } from './schema';
 
 export interface ConfigStorePaths {
   readonly applistPath: string;
@@ -104,14 +104,16 @@ function migrateInPlace(doc: Document): boolean {
   return migrated;
 }
 
-// Insert `version: SCHEMA_VERSION` at the top of the map when absent, so
-// the field leads the file the way readers expect. Mutates in memory
-// only; the caller decides whether that reaches disk. Returns whether it
-// changed anything.
-function stampVersion(doc: Document): boolean {
+// Insert `version: <version>` at the top of the map when absent, so the
+// field leads the file the way readers expect. Mutates in memory only; the
+// caller decides whether that reaches disk. The version to stamp differs by
+// caller: a legacy version-less file being read is its introduction version
+// (INITIAL_SCHEMA_VERSION), while a brand-new file macup creates is the
+// current SCHEMA_VERSION. Returns whether it changed anything.
+function stampVersion(doc: Document, version: number): boolean {
   if (!(doc.contents instanceof YAMLMap)) return false;
   if (doc.contents.has('version')) return false;
-  doc.contents.items.unshift(doc.createPair('version', SCHEMA_VERSION));
+  doc.contents.items.unshift(doc.createPair('version', version));
   return true;
 }
 
@@ -184,13 +186,15 @@ export class ConfigStore {
     this.doc = parseDocument(text);
 
     // Stamp the schema version before migrating so a legacy-key migration
-    // persists a versioned file in the same write. On a file that only
-    // lacks `version` (nothing else to migrate), this is an in-memory
-    // change that does NOT force a rewrite — the field lands the next time
-    // the user actually mutates config, keeping read-only commands
-    // side-effect free. The load-time no-change guard is baselined below
+    // persists a versioned file in the same write. A version-less file on
+    // disk is a legacy file, so it earns the INTRODUCTION version, not the
+    // current one — never silently relabel an old-shape file as a newer
+    // schema. On a file that only lacks `version` (nothing else to migrate)
+    // this is an in-memory change that does NOT force a rewrite — the field
+    // lands the next time the user mutates config, keeping read-only
+    // commands side-effect free. The no-change guard is baselined below
     // AFTER this stamp, so save() sees a version-only file as unchanged.
-    stampVersion(this.doc);
+    stampVersion(this.doc, INITIAL_SCHEMA_VERSION);
 
     let result: LoadResult = { migrated: false };
     if (migrateInPlace(this.doc)) {
@@ -394,8 +398,10 @@ export class ConfigStore {
     // the first key is added), so this is where a first-run file earns its
     // version field. On a loaded file it's a no-op — load() already
     // stamped and baselined originalText with the field, so the no-change
-    // guard below still sees a version-only file as unchanged.
-    stampVersion(doc);
+    // guard below still sees a version-only file as unchanged. A file that
+    // reaches save() without a version is one macup is creating now, so it
+    // gets the current SCHEMA_VERSION.
+    stampVersion(doc, SCHEMA_VERSION);
     const newText = doc.toString();
     if (newText === this.originalText) {
       return { changed: false };

--- a/apps/cli/test/integration/commands/config.test.ts
+++ b/apps/cli/test/integration/commands/config.test.ts
@@ -68,6 +68,15 @@ describe('buildConfigReport', () => {
     expect(r.schemaError).toContain('formulas');
   });
 
+  it('reports a newer-than-supported version as invalid, matching the store', async () => {
+    const p = paths();
+    await writeFile(p.applistPath, 'version: 999\nnpm:\n  - typescript\n', 'utf8');
+    const r = await buildConfigReport(p);
+    expect(r.schemaValid).toBe(false);
+    expect(r.schemaVersion).toBe(999);
+    expect(r.schemaError).toMatch(/newer than this macup/);
+  });
+
   it('surfaces the deprecation warning and legacy migration hint', async () => {
     const r = await buildConfigReport({
       ...paths(),

--- a/apps/cli/test/integration/config/store.test.ts
+++ b/apps/cli/test/integration/config/store.test.ts
@@ -324,3 +324,46 @@ describe('ConfigStore — backup integrity', () => {
     await expect(readdir(backupDir)).rejects.toThrow(); // dir never created
   });
 });
+
+describe('ConfigStore — schema version (#7)', () => {
+  it('loading a version-less file and not mutating leaves it byte-identical', async () => {
+    const original = 'brew:\n  formulas:\n    - git\n';
+    await seed(original);
+    const s = await store();
+    const r = await s.save('noop');
+    expect(r.changed).toBe(false);
+    expect(await readFile(applistPath, 'utf8')).toBe(original); // no surprise stamp on read
+  });
+
+  it('a real mutation stamps version: 1 at the top of the file', async () => {
+    await seed('brew:\n  formulas:\n    - git\n');
+    const s = await store();
+    s.add('brew.formulas', ['curl']);
+    await s.save('add');
+    const written = await readFile(applistPath, 'utf8');
+    expect(written.startsWith('version: 1\n')).toBe(true);
+    expect(written).toContain('curl');
+  });
+
+  it('a brand-new config is written with a version field', async () => {
+    const s = await store(); // no file on disk yet
+    s.add('npm', ['typescript']);
+    await s.save('add');
+    expect(await readFile(applistPath, 'utf8')).toContain('version: 1');
+  });
+
+  it('preserves an explicit version rather than duplicating it', async () => {
+    await seed('version: 1\nbrew:\n  formulas:\n    - git\n');
+    const s = await store();
+    s.add('brew.formulas', ['curl']);
+    await s.save('add');
+    const written = await readFile(applistPath, 'utf8');
+    expect(written.match(/version:/g)?.length).toBe(1);
+  });
+
+  it('rejects a config whose version is newer than this build supports', async () => {
+    await seed('version: 999\nnpm:\n  - typescript\n');
+    const s = new ConfigStore({ applistPath, backupDir });
+    await expect(s.load()).rejects.toThrow(/newer than this macup/);
+  });
+});

--- a/apps/cli/test/unit/config/schema.test.ts
+++ b/apps/cli/test/unit/config/schema.test.ts
@@ -1,10 +1,11 @@
 import { describe, expect, it } from 'vitest';
-import { ApplistSchema } from '../../../src/config/schema';
+import { ApplistSchema, SCHEMA_VERSION } from '../../../src/config/schema';
 
 describe('ApplistSchema', () => {
   it('accepts an empty object, defaulting all arrays and maps', () => {
     const result = ApplistSchema.parse({});
     expect(result).toEqual({
+      version: SCHEMA_VERSION,
       appstore: [],
       npm: [],
       pnpm: [],
@@ -14,8 +15,22 @@ describe('ApplistSchema', () => {
     });
   });
 
+  it('defaults version on a file that predates the field (read as v1)', () => {
+    expect(ApplistSchema.parse({ npm: ['typescript'] }).version).toBe(SCHEMA_VERSION);
+  });
+
+  it('preserves an explicit version', () => {
+    expect(ApplistSchema.parse({ version: 1, npm: [] }).version).toBe(1);
+  });
+
+  it('rejects a non-integer or non-positive version', () => {
+    expect(() => ApplistSchema.parse({ version: 0 })).toThrow();
+    expect(() => ApplistSchema.parse({ version: 1.5 })).toThrow();
+  });
+
   it('round-trips a full applist with packages, pins, and skip entries', () => {
     const input = {
+      version: SCHEMA_VERSION,
       appstore: ['Xcode'],
       npm: ['typescript'],
       pnpm: ['prettier'],


### PR DESCRIPTION
Closes #7.

Adds a `SCHEMA_VERSION` constant and a `version` field to `ApplistSchema`, defaulting to 1 so files that predate the field read as v1.

## Behaviour
- The store stamps `version` at the top of the map **lazily**: a read-only command never rewrites the file; the field lands on the next real mutation (and on first-run file creation).
- A config declaring a version **newer** than this build supports is rejected at load with an "upgrade macup" message, rather than being silently misread — that's the point of the field.
- `--config` and `--doctor` surface the version (`schema: valid (v1)`).

## Why now
Cheap while the user base is small; gives future schema changes a clean branch point instead of sniffing shape from field presence. The bundles epic (#27–#32) will add schema surface that wants this.

## Tests
Schema defaulting/rejection, plus store tests for lazy-stamp (no write on read), stamp-on-mutation, first-run creation, and future-version rejection. Verified end-to-end. `lint + typecheck + test` green (445).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
