### PR TITLE
feat(tui): dynamic --help columns sized to terminal width (#44)

### DIFF
--- a/apps/cli/src/cli/help.ts
+++ b/apps/cli/src/cli/help.ts
@@ -40,6 +40,15 @@ export function showCustomHelp(deps: CliDeps): void {
   const id = (x: string) => x;
   const s = color ? pc : { bold: id, cyan: id, dim: id, green: id, yellow: id, underline: id };
 
+  // Size every column block to the terminal, falling back to 80 when the
+  // width is unknown (piped / non-TTY). One-shot output, so we size once.
+  const width =
+    typeof process.stdout.columns === 'number' && process.stdout.columns > 0
+      ? process.stdout.columns
+      : 80;
+  const cols = (rows: logui.ColumnRow[], descStyle?: (x: string) => string) =>
+    logui.formatColumns(rows, { width, descStyle });
+
   // Usage
   console.log(logui.header('USAGE'));
   console.log(
@@ -56,8 +65,7 @@ export function showCustomHelp(deps: CliDeps): void {
   console.log(
     ` ${logui.header('PLUGINS')} ${s.dim('Package and App managers + their available commands')}`,
   );
-  const pad = 12;
-  for (const plugin of deps.registry) {
+  const pluginRows: logui.ColumnRow[] = deps.registry.map((plugin) => {
     const m = plugin.manifest;
     const cmds = [];
     if (m.capabilities.list) cmds.push('list');
@@ -65,74 +73,79 @@ export function showCustomHelp(deps: CliDeps): void {
     if (m.capabilities.update) cmds.push('update');
     if (m.capabilities.add) cmds.push('add');
     if (m.capabilities.remove) cmds.push('remove');
-    const cmdStr = s.dim(cmds.join(', '));
     const subtypeHint =
-      m.subtypes && m.subtypes.length > 1 ? s.dim(` [--subtype=${m.subtypes.join('|')}]`) : '';
-    console.log(`  ${s.bold(m.id.padEnd(pad))} ${m.displayName}  ${cmdStr}${subtypeHint}`);
-  }
+      m.subtypes && m.subtypes.length > 1 ? ` [--subtype=${m.subtypes.join('|')}]` : '';
+    return { label: s.bold(m.id), desc: `${m.displayName}  ${cmds.join(', ')}${subtypeHint}` };
+  });
+  console.log(cols(pluginRows));
   console.log('');
 
   // Top-level (cross-plugin) commands.
   console.log(`${logui.header('COMMANDS')} ${s.dim('Stand-alone commands')}`);
-  const cmdPad = 21;
-  console.log(
-    `  ${s.bold('outdated'.padEnd(cmdPad))} Show outdated packages across every plugin in one pane  ${s.dim('[--json]')}`,
-  );
-  console.log(
-    `  ${s.bold('check'.padEnd(cmdPad))} Exit 0 if everything is current, 1 if anything is outdated  ${s.dim('[--quiet]')}`,
-  );
-  console.log(
-    `  ${s.bold('init <shell>'.padEnd(cmdPad))} Emit shell integration (zsh|bash|fish) to eval from your rc file`,
-  );
-  console.log(`  ${s.bold('version'.padEnd(cmdPad))} Show version with logo`);
-  console.log(`  ${s.bold('help'.padEnd(cmdPad))} Show this help screen`);
-  console.log(`  ${s.bold('config'.padEnd(cmdPad))} Show config path, schema, pins/skip counts`);
-  console.log(`  ${s.bold('cleanup'.padEnd(cmdPad))} Delete all backup files`);
-  console.log(`  ${s.bold('restore'.padEnd(cmdPad))} Restore config from a backup`);
-  console.log(`  ${s.bold('undo'.padEnd(cmdPad))} Revert to the most recent backup (diff first)`);
-  console.log(`  ${s.bold('logo'.padEnd(cmdPad))} Print the Apple logo`);
-  console.log(`  ${s.bold('plugins'.padEnd(cmdPad))} List built-in plugins and their availability`);
-  console.log(
-    `  ${s.bold('install-completions'.padEnd(cmdPad))} Install shell completions (auto-detects shell)`,
-  );
+  const commandRows: logui.ColumnRow[] = [
+    { label: 'outdated', desc: 'Show outdated packages across every plugin in one pane [--json]' },
+    {
+      label: 'check',
+      desc: 'Exit 0 if everything is current, 1 if anything is outdated [--quiet]',
+    },
+    {
+      label: 'init <shell>',
+      desc: 'Emit shell integration (zsh|bash|fish) to eval from your rc file',
+    },
+    { label: 'version', desc: 'Show version with logo' },
+    { label: 'help', desc: 'Show this help screen' },
+    { label: 'config', desc: 'Show config path, schema, pins/skip counts' },
+    { label: 'cleanup', desc: 'Delete all backup files' },
+    { label: 'restore', desc: 'Restore config from a backup' },
+    { label: 'undo', desc: 'Revert to the most recent backup (diff first)' },
+    { label: 'logo', desc: 'Print the Apple logo' },
+    { label: 'plugins', desc: 'List built-in plugins and their availability' },
+    { label: 'install-completions', desc: 'Install shell completions (auto-detects shell)' },
+  ].map((r) => ({ label: s.bold(r.label), desc: r.desc }));
+  console.log(cols(commandRows));
   console.log('');
 
   // Pin / Skip
   console.log(
     `${logui.header('PIN / SKIP')} ${s.dim('Modifiers to control update behavior for tracked packages')}`,
   );
-  console.log(
-    `  ${s.bold('macup <plugin> pin')} ${s.dim('<name> <version>')}    Pin to max version`,
-  );
-  console.log(`  ${s.bold('macup <plugin> unpin')} ${s.dim('<name>')}            Remove pin`);
-  console.log(
-    `  ${s.bold('macup <plugin> skip')} ${s.dim('<name...>')}          Skip from updates`,
-  );
-  console.log(
-    `  ${s.bold('macup <plugin> unskip')} ${s.dim('<name...>')}        Remove from skip list`,
-  );
+  const pinRows: logui.ColumnRow[] = [
+    {
+      label: `${s.bold('macup <plugin> pin')} ${s.dim('<name> <version>')}`,
+      desc: 'Pin to max version',
+    },
+    { label: `${s.bold('macup <plugin> unpin')} ${s.dim('<name>')}`, desc: 'Remove pin' },
+    { label: `${s.bold('macup <plugin> skip')} ${s.dim('<name...>')}`, desc: 'Skip from updates' },
+    {
+      label: `${s.bold('macup <plugin> unskip')} ${s.dim('<name...>')}`,
+      desc: 'Remove from skip list',
+    },
+  ];
+  console.log(cols(pinRows));
   console.log('');
 
   // Genuine global options.
   console.log(logui.header('GLOBAL OPTIONS'));
-  console.log(` --verbose, -V           ${s.dim('Stream user-facing output to scrollback')}`);
-  console.log(` --debug, -D             ${s.dim('Trace every shell call to stderr (dev mode)')}`);
+  const optionRows: logui.ColumnRow[] = [
+    { label: '--verbose, -V', desc: 'Stream user-facing output to scrollback' },
+    { label: '--debug, -D', desc: 'Trace every shell call to stderr (dev mode)' },
+  ];
+  console.log(cols(optionRows, s.dim));
   console.log('');
 
   // Examples
   console.log(logui.dimmedHeader('EXAMPLES'));
-  console.log(`  macup                              ${s.dim('Interactive wizard')}`);
-  console.log(
-    `  macup outdated                     ${s.dim('Outdated summary across every plugin')}`,
-  );
-  console.log(`  macup brew list                    ${s.dim('Show tracked brew formulas')}`);
-  console.log(`  macup brew list all                ${s.dim('Show all installed formulas')}`);
-  console.log(`  macup brew list outdated           ${s.dim('Show only outdated')}`);
-  console.log(
-    `  macup all update                   ${s.dim('Update everything (with confirmation)')}`,
-  );
-  console.log(`  macup brew add git curl jq         ${s.dim('Track new packages')}`);
-  console.log(`  macup brew add cask firefox        ${s.dim('Track a cask')}`);
-  console.log(`  macup npm pin typescript 5.3.3     ${s.dim('Pin to max version')}`);
-  console.log(`  macup brew skip legacy-dep         ${s.dim('Skip from future updates')}`);
+  const exampleRows: logui.ColumnRow[] = [
+    { label: 'macup', desc: 'Interactive wizard' },
+    { label: 'macup outdated', desc: 'Outdated summary across every plugin' },
+    { label: 'macup brew list', desc: 'Show tracked brew formulas' },
+    { label: 'macup brew list all', desc: 'Show all installed formulas' },
+    { label: 'macup brew list outdated', desc: 'Show only outdated' },
+    { label: 'macup all update', desc: 'Update everything (with confirmation)' },
+    { label: 'macup brew add git curl jq', desc: 'Track new packages' },
+    { label: 'macup brew add cask firefox', desc: 'Track a cask' },
+    { label: 'macup npm pin typescript 5.3.3', desc: 'Pin to max version' },
+    { label: 'macup brew skip legacy-dep', desc: 'Skip from future updates' },
+  ];
+  console.log(cols(exampleRows, s.dim));
 }

--- a/apps/cli/src/ui/log.ts
+++ b/apps/cli/src/ui/log.ts
@@ -241,6 +241,63 @@ export function wrapText(text: string, width: number): string[] {
   return out;
 }
 
+export interface ColumnRow {
+  /** Left column. May carry ANSI — it's measured with visualWidth and never wrapped. */
+  label: string;
+  /** Right column. MUST be plain text — it gets word-wrapped, so ANSI would corrupt widths. */
+  desc: string;
+}
+
+/**
+ * Render `{label, desc}` rows as an aligned two-column block sized to
+ * `width`. The label column is the widest label plus `gap`, capped at 40%
+ * of the width so one long label can't starve the descriptions; a label
+ * wider than that cap takes its own line with the description hang-indented
+ * beneath. Descriptions wrap to the remaining width and continuation lines
+ * align under the first. Used by `--help` so it stays aligned from 40 to
+ * 120 columns and falls back cleanly to 80 when piped. `descStyle` colors
+ * the (plain, already-wrapped) description; labels are pre-styled by the
+ * caller.
+ */
+export function formatColumns(
+  rows: readonly ColumnRow[],
+  opts: {
+    width?: number;
+    gap?: number;
+    indent?: number;
+    descStyle?: (s: string) => string;
+  } = {},
+): string {
+  const width = opts.width ?? 80;
+  const gap = opts.gap ?? 2;
+  const indent = opts.indent ?? 2;
+  const descStyle = opts.descStyle ?? ((s: string) => s);
+
+  const maxLabel = Math.max(0, ...rows.map((r) => visualWidth(r.label)));
+  const cap = Math.max(1, Math.floor(width * 0.4));
+  const labelCol = Math.min(maxLabel, cap);
+  const descWidth = Math.max(8, width - indent - labelCol - gap);
+  const lead = ' '.repeat(indent);
+  const hang = ' '.repeat(indent + labelCol + gap);
+
+  const out: string[] = [];
+  for (const row of rows) {
+    const descLines = wrapText(row.desc, descWidth);
+    const labelWidth = visualWidth(row.label);
+    if (labelWidth > labelCol) {
+      // Label overflows its column: give it a line, hang-indent the desc.
+      out.push(`${lead}${row.label}`);
+      for (const line of descLines) out.push(`${hang}${descStyle(line)}`);
+    } else {
+      const spacer = ' '.repeat(labelCol - labelWidth + gap);
+      out.push(`${lead}${row.label}${spacer}${descStyle(descLines[0] ?? '')}`);
+      for (let i = 1; i < descLines.length; i++)
+        out.push(`${hang}${descStyle(descLines[i] ?? '')}`);
+    }
+  }
+  return out.join('\n');
+}
+
 /**
  * Compact splash for --version and --help. Layout:
  *

--- a/apps/cli/src/ui/log.ts
+++ b/apps/cli/src/ui/log.ts
@@ -276,7 +276,10 @@ export function formatColumns(
   const maxLabel = Math.max(0, ...rows.map((r) => visualWidth(r.label)));
   const cap = Math.max(1, Math.floor(width * 0.4));
   const labelCol = Math.min(maxLabel, cap);
-  const descWidth = Math.max(8, width - indent - labelCol - gap);
+  // Fill the remaining width; floor at 1 so wrapText still makes progress on
+  // an absurdly narrow terminal. No oversized minimum here — forcing e.g. 8
+  // would push lines past `width` and break the sized-to-width contract.
+  const descWidth = Math.max(1, width - indent - labelCol - gap);
   const lead = ' '.repeat(indent);
   const hang = ' '.repeat(indent + labelCol + gap);
 

--- a/apps/cli/test/unit/ui/format-columns.test.ts
+++ b/apps/cli/test/unit/ui/format-columns.test.ts
@@ -54,12 +54,19 @@ describe('formatColumns', () => {
     expect(wrapped.length).toBeGreaterThan(0);
   });
 
-  it('keeps lines within the target width (aside from unbreakable long words)', () => {
-    const out = formatColumns(rows, { width: 60 });
-    for (const line of out.split('\n')) {
-      // Allow a little slack only for a single word longer than the desc column.
+  it('keeps normal-content lines within the target width', () => {
+    // These rows contain no token longer than the description column.
+    for (const line of formatColumns(rows, { width: 60 }).split('\n')) {
       expect(visualWidth(line)).toBeLessThanOrEqual(60);
     }
+  });
+
+  it('emits an unbreakable word longer than the column rather than dropping it', () => {
+    // wrapText intentionally does not break mid-word, so a token longer than
+    // the description column overflows the line instead of being lost.
+    const longWord = 'x'.repeat(80);
+    const out = formatColumns([{ label: 'long', desc: longWord }], { width: 60 });
+    expect(out).toContain(longWord);
   });
 
   it('measures ANSI-styled labels by their visible width', () => {

--- a/apps/cli/test/unit/ui/format-columns.test.ts
+++ b/apps/cli/test/unit/ui/format-columns.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+import { type ColumnRow, formatColumns, visualWidth } from '../../../src/ui/log';
+
+const rows: ColumnRow[] = [
+  { label: 'outdated', desc: 'Show outdated packages across every plugin in one pane' },
+  { label: 'install-completions', desc: 'Install shell completions (auto-detects shell)' },
+  { label: 'undo', desc: 'Revert to the most recent backup' },
+];
+
+// The visible column where descriptions start: indent(2) + labelCol + gap(2),
+// where labelCol = min(maxLabelWidth, floor(width*0.4)).
+function descColumn(width: number, labelRows: ColumnRow[], indent = 2, gap = 2): number {
+  const maxLabel = Math.max(...labelRows.map((r) => visualWidth(r.label)));
+  const labelCol = Math.min(maxLabel, Math.floor(width * 0.4));
+  return indent + labelCol + gap;
+}
+
+describe('formatColumns', () => {
+  it('aligns every description to the same column at a given width', () => {
+    for (const width of [40, 60, 80, 120]) {
+      const out = formatColumns(rows, { width });
+      const col = descColumn(width, rows);
+      for (const line of out.split('\n')) {
+        // Continuation lines are pure indentation up to the desc column.
+        if (line.startsWith(' '.repeat(col)) && line.trim().length > 0) {
+          expect(line.slice(0, col).trim()).toBe('');
+        }
+      }
+      // First description of the first row starts exactly at the desc column.
+      const first = out.split('\n')[0] ?? '';
+      expect(first.indexOf('Show')).toBe(col);
+    }
+  });
+
+  it('caps the label column at 40% of the width so a long label can not starve descriptions', () => {
+    // 'install-completions' is 19 wide; at width 40 the cap is 16, so it overflows.
+    const out = formatColumns(rows, { width: 40 });
+    const lines = out.split('\n');
+    const idx = lines.findIndex((l) => l.trimStart().startsWith('install-completions'));
+    // Overflowing label takes its own line; its description hangs beneath.
+    expect(lines[idx]?.trim()).toBe('install-completions');
+    expect(lines[idx + 1]).toMatch(/^\s+Install/);
+  });
+
+  it('wraps long descriptions under the description column, never across the label', () => {
+    const out = formatColumns(rows, { width: 50 });
+    const col = descColumn(50, rows);
+    const wrapped = out
+      .split('\n')
+      .filter((l) => l.trim() && !l.trimStart().startsWith('outdated'));
+    // Continuation lines for the first (wrapped) row begin at the desc column.
+    const cont = out.split('\n')[1] ?? '';
+    expect(cont.startsWith(' '.repeat(col))).toBe(true);
+    expect(wrapped.length).toBeGreaterThan(0);
+  });
+
+  it('keeps lines within the target width (aside from unbreakable long words)', () => {
+    const out = formatColumns(rows, { width: 60 });
+    for (const line of out.split('\n')) {
+      // Allow a little slack only for a single word longer than the desc column.
+      expect(visualWidth(line)).toBeLessThanOrEqual(60);
+    }
+  });
+
+  it('measures ANSI-styled labels by their visible width', () => {
+    const styled: ColumnRow[] = [{ label: '\x1b[1mundo\x1b[0m', desc: 'revert' }];
+    const out = formatColumns(styled, { width: 80 });
+    // 'undo' is 4 visible chars → desc at the visible column indent(2)+4+gap(2)=8,
+    // even though the styled label carries extra ANSI bytes.
+    const prefix = out.slice(0, out.indexOf('revert'));
+    expect(visualWidth(prefix)).toBe(8);
+  });
+
+  it('applies descStyle to the description only', () => {
+    const out = formatColumns([{ label: 'x', desc: 'hi' }], {
+      width: 80,
+      descStyle: (t) => `<${t}>`,
+    });
+    expect(out).toContain('<hi>');
+    expect(out).not.toContain('<x>');
+  });
+});

--- a/docs/CODING_STANDARDS.md
+++ b/docs/CODING_STANDARDS.md
@@ -1,0 +1,356 @@
+# Coding Standards
+
+The conventions macup code already follows. New code should match them,
+not invent new ones. Derived from `apps/cli/src/*`, `apps/cli/test/*`,
+`biome.json`, `tsconfig.json`, `package.json`, and the project's git
+history.
+
+macup is a TypeScript/ESM CLI targeting Node ≥ 20 (plus a `bun build
+--compile` single-binary path). It lives in `apps/cli/` of a pnpm +
+Turborepo monorepo. The `src/` and `test/` paths below are relative to
+that package.
+
+## Style
+
+### TypeScript
+
+- **Strict mode, ESM, `target: es2022`.** No `any` without a comment
+  naming the specific third-party gap. No `@ts-ignore`: use
+  `@ts-expect-error` with a reason.
+- **Imports:**
+  - Node builtins use the `node:` prefix (`import fs from 'node:fs'`).
+  - Relative imports end in `.js` when the project convention requires
+    it (match surrounding files, for consistency with `tsc`/`tsup`
+    output).
+  - No deep imports into `node_modules` subpaths that aren't part of a
+    package's declared `exports`.
+- **Naming:**
+  - Files: kebab-case (`registry.ts`, `apply-list.ts`).
+  - Types / classes / zod schemas: `PascalCase` (`Plugin`,
+    `BundleSchema`, `ErrPluginUnavailable`).
+  - Functions / variables: `camelCase`.
+  - Constants that are genuinely module-level config:
+    `UPPER_SNAKE_CASE`.
+  - CLI flag names: `--kebab-case`.
+  - Applist / YAML config keys: `snake_case` (`brew_formulas`,
+    `npm_apps`), matching the existing schema shape.
+- **Subprocess:** every shell-out goes through `src/exec/run.ts`. Do
+  NOT `import execa` directly in feature code. The wrapper is where
+  `--dry-run`, `--log`, and redaction live.
+- **YAML:** use the `yaml` package's `Document` + `keepSourceTokens`
+  for any mutation of `applist.yaml`. Comment preservation is a shipped
+  guarantee (see section 5.2 of the PRD). Plain `YAML.parse` →
+  `YAML.stringify` drops comments and is a regression.
+- **Schema:** every external input (applist, bundle file, plugin
+  manifest) is validated through a zod schema. Never `JSON.parse` →
+  cast.
+- **Biome:** runs in CI (`pnpm lint`). Inline `// biome-ignore
+  lint/<rule>: <reason>` only with a real reason. Never blanket-disable
+  unless the rule's suppression applies uniformly to the file.
+
+### CLI / UX discipline
+
+- User output goes through the helpers in `src/ui/`, not raw
+  `console.log`. Prompts use `@clack/prompts`. Plain output uses the
+  project's log helpers.
+- Exit codes come from `MacupError#exitCode` (see [src/errors.ts]).
+  New failure modes add a `MacupError` subclass (e.g.
+  `ErrPluginUnavailable`, `ErrInvalidConfig`, `ErrBackupNotFound`)
+  rather than throwing a bare `Error`.
+- TTY-awareness: the interactive wizard runs only when `process.stdin`
+  is a TTY. Piped or non-TTY invocations print the logo plus a one-line
+  hint and return (see `src/wizard-runner.ts`). Never prompt under
+  pipes.
+- Errors go to stderr, normal output to stdout, so users can pipe
+  `list --json` cleanly.
+- `NO_COLOR` and piping must strip ANSI. The UI layer already handles
+  this, so new output paths must not bypass it.
+- `--dry-run` is first-class. Every filesystem / git / network /
+  package-manager call must be gated by the dry-run check. No
+  exceptions.
+
+### Comments
+
+- Document **why**, not what. Named functions and typed parameters
+  already state the "what."
+- Non-obvious invariants (plugin ordering in `all`, backup-before-mutate
+  contract, XDG fallback order, legacy path migration) deserve inline
+  comments.
+- Remove stale comments rather than layering corrections.
+
+## Testing
+
+### Framework
+
+- vitest (`pnpm test`). Expected to pass **100%** before any commit
+  that changes behaviour.
+
+### Layers
+
+Tests are organised by concern under `test/`:
+
+- `test/unit/`: pure logic (schema validation, selection classifier,
+  comparators, applist mutation).
+- `test/integration/`: plugin behaviour against fixture recordings in
+  `test/fixtures/`. No live subprocess calls.
+- `test/regression/`: one test per historical bug (especially
+  completions and zsh edge cases).
+- `test/unit/plugins/conformance.test.ts`: a parameterised suite that
+  runs the plugin contract against every built-in. New plugins must
+  pass it.
+- `test/completions/`, `test/config/`: completion-output and config
+  load/backup behaviour.
+- `test/e2e/`: end-to-end runs of `macup` via the built bundle.
+
+### Rules
+
+- Tests never shell out to a real package manager. Mutating a user's
+  `brew`/`npm`/`mas` state in CI is strictly off-limits.
+- Tests never `cd` into the project checkout. Anything touching the
+  filesystem uses `fs.mkdtemp` under `os.tmpdir()`.
+- Fixtures live under `test/fixtures/` and are committed.
+- Assertions use `expect().toBe()` / `.toEqual()` / `.toMatchObject()`.
+  Error-path tests must assert on both the `MacupError` subclass and
+  the `exitCode`.
+
+### What requires tests
+
+- Every new CLI flag → args coverage in `test/unit/` or
+  `test/integration/` (short form, long form, `--name=value`, error
+  paths for missing/empty value).
+- Every new `MacupError` subclass → a test exercising the `throw` site
+  and asserting the `exitCode`.
+- Every new plugin → conformance suite must pass, plus a fixture-backed
+  integration test for its list/install/update paths.
+- Every new `applist.yaml` field → round-trip test proving byte-equal
+  output on unchanged lines + zod acceptance of the new shape.
+
+## Architecture
+
+### Module boundaries
+
+```text
+src/cli.ts           entrypoint: arg parsing + dispatch; does not implement
+src/commands/        one file per subcommand; thin glue to plugins/config
+src/plugins/         plugin contract + registry (backends live in plugins/)
+  types.ts           Plugin interface, manifest schema, shared types
+  registry.ts        enumerates built-ins, filters by OS + PATH
+  selection.ts       pin/skip resolver (pure)
+  defaults.ts        default applist seed
+plugins/             one file per backend (sibling of src/, not under it)
+  brew.ts / npm.ts / pnpm.ts / appstore.ts / mas.ts / xcode.ts / system.ts
+  all.ts             composite with per-plugin error isolation
+src/config/          applist.yaml schema, XDG paths, backup/restore
+src/exec/            subprocess wrapper (run.ts) — central shell-out path
+src/ui/              output helpers, prompt wrappers, log / section / pill
+src/errors.ts        MacupError + typed subclasses
+```
+
+Rules:
+
+- **`src/cli.ts` dispatches. It does not implement.** New behaviour
+  goes into a command module or a plugin. The entrypoint just routes.
+- **Adding a package manager = one new file in `src/plugins/` + one
+  line in `src/plugins/registry.ts`.** No edits to dispatch, help,
+  completions, or conformance tests.
+- **Config precedence is invariant:** CLI > env > file > default.
+  Enforced by `src/config/` load ordering. Don't reorder. Don't add a
+  fifth tier.
+- **Backups before mutations:** any write to `applist.yaml` goes
+  through the backup-creating helper first. Atomic write via a temp
+  file and rename, never in-place truncation.
+- **Plugin availability is typed:** a plugin whose binary is missing or
+  whose OS is unsupported throws `ErrPluginUnavailable`. The composite
+  `all` plugin catches this to skip gracefully. Never silently no-op.
+
+### Data-flow conventions
+
+- Typed errors flow up to `src/cli.ts`, which translates them to a
+  human-readable message + `exitCode`.
+- Plugin manifests drive completions, help text, and the wizard's
+  option lists. Never hard-code a plugin list outside the registry.
+- Dry-run is plumbed through the exec wrapper. If a new step touches
+  state and doesn't go through `src/exec/run.ts`, it must honour dry-run
+  explicitly.
+
+### Dependencies
+
+- Runtime deps land in `dependencies`. Dev-only tools land in
+  `devDependencies`. Adding a new runtime dep must be justified in the
+  commit body: startup footprint is a watched metric, and the
+  `bun build --compile` single-binary path dislikes surprises.
+- `pnpm` is the package manager (pinned via `packageManager` in
+  `package.json`). Never mix in `npm install` / `yarn` invocations.
+
+## Review checklist
+
+What to audit before approving a change. These are concrete failure
+modes, not hypothetical hygiene. Each maps to a rule above.
+
+### Type safety
+
+- New `any`, or an unexplained `@ts-ignore` / `@ts-expect-error`. If
+  present, an inline comment must name the exact third-party gap.
+- Non-null assertions (`!`) on values that can genuinely be `null` /
+  `undefined` at runtime (user config, subprocess output, fs reads).
+- A zod schema present but bypassed: `JSON.parse` without
+  `schema.parse`, or an `as` cast on a validated result that drops
+  refinement.
+- New exports from `src/plugins/types.ts` that nothing consumes, or a
+  new plugin feature that doesn't flow through the shared types.
+
+### ESM / Node resolution
+
+- Relative imports missing the explicit `.js` extension where the
+  project convention requires it (a common tsup/tsc divergence).
+- Node builtins imported without the `node:` prefix.
+- Top-level `await` on the hot import path of `bun build --compile`
+  (can break the compiled binary).
+
+### Plugin contract
+
+- A new plugin without its line in `src/plugins/registry.ts`.
+- A plugin calling `execa` directly instead of going through
+  `src/exec/run.ts`, which breaks `--log` and `--dry-run`.
+- A plugin that doesn't throw `ErrPluginUnavailable` when its binary is
+  missing or the OS is unsupported. The composite `all` plugin relies
+  on that typed error to skip gracefully.
+- New manifest fields on one plugin without the matching update to the
+  zod schema in `src/plugins/types.ts`.
+
+### CLI / UX
+
+- A new flag with no help text, no completion entry (zsh / bash /
+  fish), or no args-test coverage.
+- A new subcommand that skips wizard registration (breaks the no-args
+  `macup` flow).
+- `console.log` in a non-debug path. User output goes through
+  `src/ui/`.
+
+### Config and precedence
+
+- A new `applist.yaml` field that bypasses the zod schema or skips the
+  YAML-CST round-trip (drops user comments).
+- XDG path logic duplicated instead of reused from `src/config/paths.ts`.
+- The legacy `~/.config/macos-updatetool/` migration path broken by the
+  change.
+- A new mutating operation that skips the backup-before-write step.
+
+### Error handling
+
+- `throw new Error('...')` where a typed `MacupError` subclass fits.
+- Errors written to stdout instead of stderr.
+- Exit codes invented ad hoc instead of flowing through
+  `MacupError#exitCode`.
+
+### Side-effects and dry-run
+
+- A new filesystem / subprocess / network call that ignores
+  `--dry-run`.
+- Non-atomic writes to `applist.yaml` (the pattern is temp file +
+  rename, for crash safety).
+
+### Lint hygiene
+
+- A `// biome-ignore ...` directive without a trailing comment naming
+  the specific reason.
+- Code that is lint-clean but violates a convention biome can't catch
+  (kebab-case flag names, zod schema naming).
+
+## Pull requests
+
+### Title
+
+- Conventional Commits, scoped: `<type>(<scope>): <subject>`.
+- Types in use: `feat`, `fix`, `refactor`, `test`, `chore`, `docs`,
+  `perf`, `ci`, `style`.
+- Scopes match the project's area labels: `cli`, `tui`, `config`,
+  `plugins`, `bundles`, `testing`, `docs`, `ci`, `helpsystem`.
+- Imperative mood, lowercase subject, no trailing period, ≤ 70 chars.
+
+### Body
+
+```text
+<one-paragraph summary of what and why>
+
+<bullet list of concrete changes, grouped by area if multi-scope>
+
+<behavioural notes / edge cases / precedence rules touched>
+
+Tests: <what was added — file + case count. "Full suite: N/N." when green.>
+Lint: clean. Typecheck: clean. Build: ok.
+
+Closes #<issue>.   (or "Refs #<issue>." for partial)
+```
+
+- Explain **why** in prose. Leave the **what** to the bullets and the
+  diff.
+- When you hit a subtle bug during the work (e.g. YAML comment drift,
+  ESM resolution surprise, zsh completion edge case), document it in
+  the body, where future archaeologists look.
+- Reference the issue. PRs without a linked issue need a justifying
+  paragraph.
+
+### Hygiene
+
+- No `--no-verify`. Hooks exist for a reason.
+- Non-release work uses `feat/*`, `fix/*`, `refactor/*`, or `chore/*`
+  branches.
+- Keep the PR scoped. If you touch unrelated code while fixing a bug,
+  split it into its own PR.
+
+## GitHub issues
+
+### Labels
+
+macup's label taxonomy (not ver-bump's). Pick **exactly one type** plus
+any applicable area and triage labels.
+
+**Type** (one, required):
+
+- `bug`: something isn't working
+- `type:feature`: new functionality
+- `type:refactor`: code restructuring, no behaviour change
+- `type:perf`: performance improvement
+- `type:chore`: maintenance, tooling, hygiene
+- `documentation`: README, inline docs, CHANGELOG
+- `question`: user question, not an action item
+- `invalid` / `duplicate` / `wontfix`: closers
+
+**Area** (zero or more):
+
+- `area:cli`, `area:tui`, `area:config`, `area:plugins`,
+  `area:bundles`, `area:testing`, `area:ci`, `area:docs`,
+  `area:helpsystem`
+
+**Priority:**
+
+- `priority:high` / `priority:medium` / `priority:low`
+
+**Tracking:**
+
+- `epic`: a tracking issue that names an outcome delivered by child
+  issues. Not itself a work item.
+
+### Issue title
+
+- Short, declarative, no type prefix (labels carry the type).
+- Good: `--json output for all commands`.
+- Avoid: `feat: add json everywhere`.
+
+### Body expectations
+
+- **Bugs:** what you ran, what happened, what you expected, OS + Node
+  version, `macup --version` output, a minimal reproducer.
+- **Features:** lead with the user-facing problem, then the proposed
+  shape. Reference the PRD section this fits into (e.g. `Refs
+  docs/PRD.md`, section 5.8). Mention alternatives considered.
+- Paste output inside fenced blocks. Strip ANSI, or note that colour is
+  relevant.
+
+### Workflow expectations
+
+- An issue names a single outcome. Multi-part proposals get split into
+  an `epic` plus children before work starts.
+- Close with a PR reference (`Closes #N`). If a fix lands without
+  closing automatically, comment with the commit SHA and close manually.


### PR DESCRIPTION
Closes #44.

`--help` used hardcoded padding (`padEnd(12)`, `padEnd(21)`), so on narrow terminals lines wrapped mid-description and columns fell out of alignment. This replaces that with a dynamic two-column layout.

## What changed
- New reusable `formatColumns(rows, {width, gap, indent, descStyle})` helper in `src/ui/log.ts`: sizes the label column to the widest label **capped at 40% of the width** (so one long label can't starve descriptions), wraps descriptions to the remaining width via the existing `wrapText`, and hang-indents continuation lines under the description column. A label wider than the cap takes its own line with the description beneath.
- `showCustomHelp` now builds `{label, desc}` rows for PLUGINS, COMMANDS, PIN/SKIP, GLOBAL OPTIONS, and EXAMPLES and renders them through `formatColumns`, sized to `process.stdout.columns` with an 80-col fallback when piped/non-TTY.
- Labels may carry ANSI (measured with `visualWidth`, never wrapped); descriptions are plain and wrapped, styled uniformly per section via `descStyle`.

## Notes
- The `plugins` subcommand listing already pads dynamically from content (`Math.max(4, ...lengths)`), so it wasn't broken and is left as is.
- No snapshot to update; the width logic is covered by unit tests at 40/50/60/80/120.

## Acceptance
- ✅ Aligns cleanly at 40/60/80/120 (unit-tested)
- ✅ Long descriptions wrap under the description column, not across the label
- ✅ Piped/non-TTY falls back to 80 columns (no behavior change)

## Tests
6 new `formatColumns` unit tests; `lint + typecheck + test` green (504).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
