### PR TITLE
feat(wizard): search & add packages in the wizard (#37)

### DIFF
--- a/apps/cli/plugins/brew.ts
+++ b/apps/cli/plugins/brew.ts
@@ -6,6 +6,8 @@ import type {
   PackageStatus,
   Plugin,
   PluginContext,
+  SearchOptions,
+  SearchResult,
 } from '../src/plugins/types';
 
 interface OutdatedFormula {
@@ -175,6 +177,26 @@ const brew: Plugin = {
     opts: MutateOptions,
   ): Promise<void> {
     await runAll(ctx, refs, 'upgrade', opts);
+  },
+
+  async search(ctx: PluginContext, query: string, opts?: SearchOptions): Promise<SearchResult[]> {
+    // Scope to a subtype so the output is a flat name list. Unscoped
+    // `brew search` interleaves `==> Formulae` / `==> Casks` headers; the
+    // filter below drops those defensively in case the flag is ignored.
+    const args = ['search'];
+    if (opts?.subtype === 'casks') args.push('--cask');
+    else if (opts?.subtype === 'formulas') args.push('--formula');
+    args.push(query);
+    const { stdout } = await ctx.exec.run('brew', args, { signal: ctx.signal, kind: 'query' });
+    const seen = new Set<string>();
+    const results: SearchResult[] = [];
+    for (const raw of stdout.split('\n')) {
+      const name = raw.trim();
+      if (!name || name.startsWith('==>') || seen.has(name)) continue;
+      seen.add(name);
+      results.push({ name });
+    }
+    return results;
   },
 };
 

--- a/apps/cli/plugins/npm.ts
+++ b/apps/cli/plugins/npm.ts
@@ -6,6 +6,7 @@ import type {
   PackageStatus,
   Plugin,
   PluginContext,
+  SearchResult,
 } from '../src/plugins/types';
 
 interface NpmListResponse {
@@ -118,6 +119,23 @@ const npm: Plugin = {
     opts: MutateOptions,
   ): Promise<void> {
     await runAll(ctx, refs, 'update', opts);
+  },
+
+  async search(ctx: PluginContext, query: string): Promise<SearchResult[]> {
+    const { stdout } = await ctx.exec.run('npm', ['search', '--json', query], {
+      signal: ctx.signal,
+      kind: 'query',
+    });
+    const parsed = safeParseJson<Array<{ name?: string; description?: string }>>(stdout);
+    if (!Array.isArray(parsed)) return [];
+    const results: SearchResult[] = [];
+    for (const hit of parsed) {
+      if (!hit || typeof hit.name !== 'string') continue;
+      results.push(
+        hit.description ? { name: hit.name, description: hit.description } : { name: hit.name },
+      );
+    }
+    return results;
   },
 };
 

--- a/apps/cli/src/plugins/types.ts
+++ b/apps/cli/src/plugins/types.ts
@@ -114,10 +114,29 @@ export interface MutateOptions {
   readonly dryRun?: boolean;
 }
 
+export interface SearchOptions {
+  /** Scope the search to one subtype (e.g. 'formulas' | 'casks' for brew). */
+  readonly subtype?: string;
+}
+
+/** One hit from a plugin's package search (the wizard's add flow). */
+export interface SearchResult {
+  readonly name: string;
+  /** Short blurb when the backend provides one (npm does; brew search doesn't). */
+  readonly description?: string;
+}
+
 export interface Plugin {
   readonly manifest: PluginManifest;
   check(ctx: PluginContext): Promise<void>;
   list(ctx: PluginContext, opts: ListOptions): Promise<PackageStatus[]>;
   install?(ctx: PluginContext, refs: readonly PackageRef[], opts: MutateOptions): Promise<void>;
   update?(ctx: PluginContext, refs: readonly PackageRef[], opts: MutateOptions): Promise<void>;
+  /**
+   * Optional: search the backend's registry for packages matching `query`.
+   * Powers the wizard's "Search & add" flow so a user who can't recall an
+   * exact name can pick from results. Presence of this method is the
+   * capability signal — there is no separate capabilities flag.
+   */
+  search?(ctx: PluginContext, query: string, opts?: SearchOptions): Promise<SearchResult[]>;
 }

--- a/apps/cli/src/wizard-runner.ts
+++ b/apps/cli/src/wizard-runner.ts
@@ -11,7 +11,7 @@
 // promptTrackedSetPicker, applySyncTracked) sit together instead of
 // scattered through a 988-line file.
 
-import { isCancel, note, select, spinner } from '@clack/prompts';
+import { isCancel, note, select, spinner, text } from '@clack/prompts';
 import { type CommandDef, runCommand } from 'citty';
 import pc from 'picocolors';
 import type { CliDeps } from './cli/types';
@@ -175,6 +175,75 @@ async function promptTrackedSetPicker(
     message: pickerMessage(`Tracked packages for ${label}`, summary, deps.color),
     options,
     initialValues: [...trackedNames],
+    maxItems: pickerMaxItems(total),
+    required: false,
+  });
+  return isCancel(choice) ? null : (choice as readonly string[]);
+}
+
+// "Search & add" picker. Prompts for a query, runs the plugin's search
+// against the backend registry, and returns the names the user chose to
+// track (or null to nav back). Only offered when the plugin exposes
+// `search`; the pick flows through the same ConfigStore add path as
+// Add/Remove.
+async function promptSearchAndPick(
+  target: Target,
+  deps: CliDeps,
+): Promise<readonly string[] | null> {
+  const plugin = deps.registry.find((p) => p.manifest.id === target.pluginId);
+  if (!plugin?.search) {
+    console.error(`error: plugin "${target.pluginId}" does not support search`);
+    return null;
+  }
+  const label = target.subtype ? `${target.pluginId}:${target.subtype}` : target.pluginId;
+
+  const query = await text({
+    message: `Search ${label} for a package`,
+    placeholder: 'e.g. prettier',
+    validate: (v) => (!v || v.trim().length === 0 ? 'Enter a search term.' : undefined),
+  });
+  if (isCancel(query) || typeof query !== 'string') return null;
+
+  const ctx: PluginContext = { exec: deps.exec, log: deps.log, signal: deps.signal };
+  const s = spinner();
+  s.start(`Searching ${label} for “${query.trim()}”…`);
+  let results: Awaited<ReturnType<NonNullable<typeof plugin.search>>>;
+  try {
+    await plugin.check(ctx);
+    results = await plugin.search(ctx, query.trim(), { subtype: target.subtype });
+  } catch (err) {
+    s.stop(`Search failed for ${label}.`);
+    console.error(`error: ${err instanceof Error ? err.message : String(err)}`);
+    return null;
+  }
+  s.stop(`Searched ${label}.`);
+
+  if (results.length === 0) {
+    console.log(logui.info(`No ${label} packages matched “${query.trim()}”.`));
+    return null;
+  }
+
+  const store = await deps.getStore();
+  const configKey = plugin.manifest.configKeyFor
+    ? plugin.manifest.configKeyFor(target.subtype)
+    : plugin.manifest.configKeys[0];
+  const tracked = new Set(configKey ? store.list(configKey) : []);
+
+  const total = results.length;
+  const choice = await pageableAutocompleteMultiselect<string>({
+    message: pickerMessage(
+      `Results for “${query.trim()}”`,
+      `${total} ${total === 1 ? 'match' : 'matches'}`,
+      deps.color,
+    ),
+    options: results.map((r) => {
+      const tags: string[] = [];
+      if (tracked.has(r.name)) tags.push('tracked');
+      if (r.description) tags.push(r.description);
+      const opt: { label: string; value: string; hint?: string } = { label: r.name, value: r.name };
+      if (tags.length > 0) opt.hint = tags.join(' · ');
+      return opt;
+    }),
     maxItems: pickerMaxItems(total),
     required: false,
   });
@@ -373,6 +442,7 @@ export async function runWizard(
             return store.list(key);
           },
           pickTrackedSet: async (t) => promptTrackedSetPicker(t, deps),
+          searchAndPick: async (t) => promptSearchAndPick(t, deps),
         },
         target,
       );

--- a/apps/cli/src/wizard.ts
+++ b/apps/cli/src/wizard.ts
@@ -60,7 +60,8 @@ export interface WizardDeps {
   /**
    * "Search & add": prompt for a query, search the backend, and return the
    * package names the user chose to track — or null to nav back. Required
-   * when the target's plugin exposes `search`.
+   * only when the search-add action is offered, i.e. when the plugin exposes
+   * `search` AND can track additions (add capability + a configKey).
    */
   readonly searchAndPick?: (target: Target) => Promise<readonly string[] | null>;
   /** Reads current tracked names for the given target. Required when sync-tracked is offered. */

--- a/apps/cli/src/wizard.ts
+++ b/apps/cli/src/wizard.ts
@@ -19,7 +19,13 @@ export type ActionResult =
       readonly removes: readonly string[];
     };
 
-export type WizardActionOption = 'list' | 'update' | 'update-selected' | 'sync-tracked' | 'install';
+export type WizardActionOption =
+  | 'list'
+  | 'update'
+  | 'update-selected'
+  | 'sync-tracked'
+  | 'search-add'
+  | 'install';
 
 export interface WizardDeps {
   readonly plugins: readonly Plugin[];
@@ -51,6 +57,12 @@ export interface WizardDeps {
    * (any subset of installed ∪ tracked), or null to nav back.
    */
   readonly pickTrackedSet?: (target: Target) => Promise<readonly string[] | null>;
+  /**
+   * "Search & add": prompt for a query, search the backend, and return the
+   * package names the user chose to track — or null to nav back. Required
+   * when the target's plugin exposes `search`.
+   */
+  readonly searchAndPick?: (target: Target) => Promise<readonly string[] | null>;
   /** Reads current tracked names for the given target. Required when sync-tracked is offered. */
   readonly currentTracked?: (target: Target) => Promise<readonly string[]>;
   /** Fetches outdated rows for "Update selected". Required alongside pickOutdated. */
@@ -132,6 +144,7 @@ const ACTION_LABELS: Record<WizardActionOption, string> = {
   list: 'List tracked',
   update: 'Update tracked',
   'sync-tracked': 'Add/Remove',
+  'search-add': 'Search & add',
   'update-selected': 'Update selectively',
   install: 'Install tracked',
 };
@@ -143,6 +156,8 @@ function actionsFor(plugin: Plugin): WizardActionOption[] {
   if (cap.list) opts.push('list');
   if (cap.update) opts.push('update');
   if (cap.add && cap.remove && hasConfigKey) opts.push('sync-tracked');
+  // Search-add needs somewhere to record the pick and a backend to query.
+  if (cap.add && hasConfigKey && typeof plugin.search === 'function') opts.push('search-add');
   if (cap.update && cap.outdated) opts.push('update-selected');
   if (cap.install) opts.push('install');
   return opts;
@@ -191,6 +206,18 @@ export async function pickAction(deps: WizardDeps, target: Target): Promise<Acti
       const picked = await deps.pickOutdated(target, rows);
       if (picked === null || picked.length === 0) continue;
       return { kind: 'dispatch', target, command: 'update', packages: picked };
+    }
+
+    if (choice === 'search-add') {
+      if (!deps.searchAndPick) {
+        console.error('error: wizard cannot run "Search & add" without a searchAndPick handler');
+        return null;
+      }
+      const picked = await deps.searchAndPick(target);
+      if (picked === null || picked.length === 0) continue; // cancelled / nothing chosen
+      // Reuse the sync-tracked apply path: the picks are pure adds. The
+      // ConfigStore dedups anything already tracked.
+      return { kind: 'sync-tracked', target, adds: picked, removes: [] };
     }
 
     // 'sync-tracked'

--- a/apps/cli/test/integration/plugins/brew.test.ts
+++ b/apps/cli/test/integration/plugins/brew.test.ts
@@ -120,3 +120,34 @@ describe('brew plugin — update', () => {
     ).resolves.toBeUndefined();
   });
 });
+
+describe('brew plugin — search', () => {
+  function ctxWith(args: string[], stdout: string): PluginContext {
+    return {
+      exec: new FixtureExecRunner({
+        fixtures: [{ cmd: 'brew', args, result: { stdout, stderr: '', exitCode: 0 } }],
+        onPath: ['brew'],
+      }),
+      log: { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} },
+      signal: new AbortController().signal,
+    };
+  }
+
+  it('scopes to --formula for the formulas subtype and returns names', async () => {
+    const ctx = ctxWith(['search', '--formula', 'node'], 'node\nnode@18\nnodenv\n');
+    const results = await brewPlugin.search?.(ctx, 'node', { subtype: 'formulas' });
+    expect(results).toEqual([{ name: 'node' }, { name: 'node@18' }, { name: 'nodenv' }]);
+  });
+
+  it('scopes to --cask for the casks subtype', async () => {
+    const ctx = ctxWith(['search', '--cask', 'firefox'], 'firefox\nfirefox@developer-edition\n');
+    const results = await brewPlugin.search?.(ctx, 'firefox', { subtype: 'casks' });
+    expect(results?.map((r) => r.name)).toEqual(['firefox', 'firefox@developer-edition']);
+  });
+
+  it('drops ==> section headers and de-dupes if the scope flag is ignored', async () => {
+    const ctx = ctxWith(['search', 'node'], '==> Formulae\nnode\nnodenv\n==> Casks\nnode\n');
+    const results = await brewPlugin.search?.(ctx, 'node');
+    expect(results).toEqual([{ name: 'node' }, { name: 'nodenv' }]);
+  });
+});

--- a/apps/cli/test/integration/plugins/npm.test.ts
+++ b/apps/cli/test/integration/plugins/npm.test.ts
@@ -97,3 +97,46 @@ describe('npm plugin — update', () => {
     ).resolves.toBeUndefined();
   });
 });
+
+describe('npm plugin — search', () => {
+  function ctxWith(stdout: string): PluginContext {
+    return {
+      exec: new FixtureExecRunner({
+        fixtures: [
+          {
+            cmd: 'npm',
+            args: ['search', '--json', 'prettier'],
+            result: { stdout, stderr: '', exitCode: 0 },
+          },
+        ],
+        onPath: ['npm'],
+      }),
+      log: { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} },
+      signal: new AbortController().signal,
+    };
+  }
+
+  it('parses `npm search --json` into name + description results', async () => {
+    const ctx = ctxWith(
+      JSON.stringify([
+        { name: 'prettier', description: 'Prettier is an opinionated code formatter' },
+        { name: 'prettier-eslint', description: 'Formats with prettier then eslint' },
+      ]),
+    );
+    const results = await npmPlugin.search?.(ctx, 'prettier');
+    expect(results).toEqual([
+      { name: 'prettier', description: 'Prettier is an opinionated code formatter' },
+      { name: 'prettier-eslint', description: 'Formats with prettier then eslint' },
+    ]);
+  });
+
+  it('returns [] on empty or non-array output rather than throwing', async () => {
+    expect(await npmPlugin.search?.(ctxWith(''), 'prettier')).toEqual([]);
+    expect(await npmPlugin.search?.(ctxWith('not json'), 'prettier')).toEqual([]);
+  });
+
+  it('drops entries without a name', async () => {
+    const ctx = ctxWith(JSON.stringify([{ description: 'no name here' }, { name: 'ok' }]));
+    expect(await npmPlugin.search?.(ctx, 'prettier')).toEqual([{ name: 'ok' }]);
+  });
+});

--- a/apps/cli/test/unit/wizard.test.ts
+++ b/apps/cli/test/unit/wizard.test.ts
@@ -246,6 +246,35 @@ describe('pickAction — option gating', () => {
     expect(offered).toContain('update');
   });
 
+  it('offers search-add only when the plugin exposes a search method', async () => {
+    const searchable: Plugin = { ...mkPlugin('brew'), search: async () => [] };
+    let offered: WizardActionOption[] = [];
+    await pickAction(
+      {
+        plugins: [searchable],
+        selectTarget: async () => null,
+        selectAction: async (_t, opts) => {
+          offered = opts.map((o) => o.value);
+          return null;
+        },
+      },
+      { pluginId: 'brew' },
+    );
+    expect(offered).toContain('search-add');
+    // Not offered on the plain brew fixture (no search method).
+    let plain: WizardActionOption[] = [];
+    await pickAction(
+      emptyDeps({
+        selectAction: async (_t, opts) => {
+          plain = opts.map((o) => o.value);
+          return null;
+        },
+      }),
+      { pluginId: 'brew' },
+    );
+    expect(plain).not.toContain('search-add');
+  });
+
   it('returns null when the user cancels the action prompt', async () => {
     const result = await pickAction(emptyDeps(), { pluginId: 'brew' });
     expect(result).toBeNull();
@@ -396,5 +425,67 @@ describe('pickAction — sync-tracked diff', () => {
     );
     expect(actionCalls).toBe(2);
     expect(result).toBeNull();
+  });
+});
+
+describe('pickAction — search-add', () => {
+  const searchable: Plugin = { ...mkPlugin('brew'), search: async () => [] };
+
+  it('returns kind:sync-tracked with the picked names as pure adds', async () => {
+    let searchedTarget: unknown;
+    const result = await pickAction(
+      {
+        plugins: [searchable],
+        selectTarget: async () => null,
+        selectAction: async () => 'search-add',
+        searchAndPick: async (t) => {
+          searchedTarget = t;
+          return ['prettier', 'eslint'];
+        },
+      },
+      { pluginId: 'brew' },
+    );
+    expect(searchedTarget).toEqual({ pluginId: 'brew' });
+    expect(result).toEqual<ActionResult>({
+      kind: 'sync-tracked',
+      target: { pluginId: 'brew' },
+      adds: ['prettier', 'eslint'],
+      removes: [],
+    });
+  });
+
+  it('re-prompts the action when the picker is cancelled or empty', async () => {
+    for (const picked of [null, [] as string[]]) {
+      let actionCalls = 0;
+      const result = await pickAction(
+        {
+          plugins: [searchable],
+          selectTarget: async () => null,
+          selectAction: async () => {
+            actionCalls++;
+            return actionCalls === 1 ? 'search-add' : null;
+          },
+          searchAndPick: async () => picked,
+        },
+        { pluginId: 'brew' },
+      );
+      expect(actionCalls).toBe(2);
+      expect(result).toBeNull();
+    }
+  });
+
+  it('errors when search-add is chosen without a searchAndPick handler', async () => {
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const result = await pickAction(
+      {
+        plugins: [searchable],
+        selectTarget: async () => null,
+        selectAction: async () => 'search-add',
+      },
+      { pluginId: 'brew' },
+    );
+    expect(result).toBeNull();
+    expect(errSpy).toHaveBeenCalled();
+    errSpy.mockRestore();
   });
 });


### PR DESCRIPTION
Closes #37.

When the wizard's target has a searchable backend, it now offers a **Search & add** action so a user who can't recall an exact package name can find it and track it — instead of having to type names up front.

## What changed
- **New optional `plugin.search(ctx, query, opts?)`** on the `Plugin` interface, returning `{name, description?}[]`. Presence of the method is the capability signal — no new manifest flag, so nothing else in the plugin contract or conformance suite changes.
- **brew**: `brew search --formula|--cask <query>` (scoped by the target's subtype), with a defensive filter that drops `==> Formulae`/`==> Casks` headers and de-dupes.
- **npm**: `npm search --json <query>`, parsed into name + description (tolerant of empty/non-array output).
- **Wizard**: a `search-add` action, offered when the plugin exposes `search` and can track (add + configKey). It prompts for a query, runs the search with a spinner, shows results in the existing autocomplete multiselect (description shown as a dim hint, `tracked` tag for already-tracked hits), and flows the picks through the **existing sync-tracked add path** so `ConfigStore` dedups anything already tracked.

## Verified
Parser assumptions checked against real output: scoped `brew search` returns flat names (no headers), `npm search --json` returns objects with `name`/`description`. Non-goal per the issue: this isn't a full discovery UX, just the "I know it exists but forget the exact name" case.

## Tests
brew + npm search integration tests (FixtureExecRunner) covering scoping, header-drop/de-dupe, description parsing, and malformed output; wizard unit tests for the action gating (offered only with `search`), the sync-tracked result shape, cancel/empty re-prompt, and the missing-handler error. `lint + typecheck + test` green (508).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
