### PR TITLE
fix(cli): list --json errors + shellcheck-clean bash completions

### DIFF
--- a/apps/cli/src/commands/from-manifest.ts
+++ b/apps/cli/src/commands/from-manifest.ts
@@ -165,8 +165,11 @@ export function commandsFromManifest(plugin: Plugin, deps: CommandDeps): Command
           },
         };
 
+        // --json owns stdout, and the bar's "... done." lands there on a TTY,
+        // so a piped-to-jq run would break on an interactive terminal but pass
+        // in CI. suppressBar is the existing seam for exactly this.
         let statuses = await withSpinner(
-          deps,
+          showJson ? { ...deps, suppressBar: true } : deps,
           `Fetching ${manifest.displayName} packages...`,
           async () => {
             await plugin.check(listCtx);
@@ -203,11 +206,15 @@ export function commandsFromManifest(plugin: Plugin, deps: CommandDeps): Command
           if (tracked.size > 0) {
             statuses = statuses.filter((s) => tracked.has(s.ref.name));
           } else {
-            console.log(
-              log.warning(
-                `No tracked packages. Showing all installed. Add with: macup ${manifest.id} add <name...>`,
-              ),
+            // Advice for a human, not part of the payload. On stdout it would
+            // precede the JSON and break the parse, so --json routes it to
+            // stderr rather than dropping it: piped output stays valid and the
+            // hint still reaches a watching terminal.
+            const notice = log.warning(
+              `No tracked packages. Showing all installed. Add with: macup ${manifest.id} add <name...>`,
             );
+            if (showJson) console.error(notice);
+            else console.log(notice);
           }
         }
 

--- a/apps/cli/src/commands/from-manifest.ts
+++ b/apps/cli/src/commands/from-manifest.ts
@@ -128,7 +128,7 @@ export function commandsFromManifest(plugin: Plugin, deps: CommandDeps): Command
         },
         json: {
           type: 'boolean',
-          description: 'Output as JSON (PackageStatus[]).',
+          description: 'Output as JSON: PackageStatus[], or { error, packages } if a query fails.',
         },
       },
       async run({ args }) {
@@ -147,12 +147,30 @@ export function commandsFromManifest(plugin: Plugin, deps: CommandDeps): Command
         const showJson = Boolean(args.json);
         const showAll = Boolean(args.all);
 
+        // Capture query-failure warnings the plugin emits via ctx.log.warn
+        // (e.g. pnpm's "global bin dir not in PATH") so --json can carry an
+        // `error` field instead of an empty list — an errored query is
+        // otherwise indistinguishable from a genuinely empty one (A-2/#51).
+        // The wrapped warn still delegates, so default mode keeps printing
+        // the warning line.
+        const queryWarnings: string[] = [];
+        const listCtx: PluginContext = {
+          ...makeCtx(deps),
+          log: {
+            ...deps.log,
+            warn: (m: string) => {
+              queryWarnings.push(m);
+              deps.log.warn(m);
+            },
+          },
+        };
+
         let statuses = await withSpinner(
           deps,
           `Fetching ${manifest.displayName} packages...`,
           async () => {
-            await plugin.check(makeCtx(deps));
-            return plugin.list(makeCtx(deps), {
+            await plugin.check(listCtx);
+            return plugin.list(listCtx, {
               subtype,
               onlyOutdated: Boolean(args['only-outdated']),
             });
@@ -194,7 +212,14 @@ export function commandsFromManifest(plugin: Plugin, deps: CommandDeps): Command
         }
 
         if (showJson) {
-          console.log(JSON.stringify(statuses, null, 2));
+          // On a query failure, emit an object with an `error` field instead
+          // of a bare array, so a consumer can tell "errored" from "empty"
+          // (#51). The success path keeps the documented PackageStatus[] shape.
+          const payload =
+            queryWarnings.length > 0
+              ? { error: queryWarnings.join('; '), packages: statuses }
+              : statuses;
+          console.log(JSON.stringify(payload, null, 2));
         } else {
           console.log(renderList(manifest.displayName, statuses, Boolean(args['only-outdated'])));
         }

--- a/apps/cli/src/completions/bash.ts
+++ b/apps/cli/src/completions/bash.ts
@@ -25,12 +25,17 @@ export function generateBashCompletions(plugins: readonly Plugin[]): string {
     )
     .join('\n');
 
+  // shellcheck disable=SC2207: the $(compgen ...) word-splitting below is the
+  // standard bash-completion idiom. mapfile/read -a would be cleaner but need
+  // bash 4+, and macOS ships bash 3.2 — so keep the array-split and silence the
+  // warning file-wide. Placed in the header (before the first command) so the
+  // directive applies to the whole generated script.
   return `# Auto-generated from plugin manifests. Do not edit.
+# shellcheck disable=SC2207
 
 _macup() {
-  local cur prev
+  local cur
   cur="\${COMP_WORDS[COMP_CWORD]}"
-  prev="\${COMP_WORDS[COMP_CWORD-1]}"
 
   if [[ \${COMP_CWORD} -eq 1 ]]; then
     COMPREPLY=( $(compgen -W "${ids.join(' ')} ${globalFlags}" -- "$cur") )

--- a/apps/cli/test/integration/commands/list-json-error.test.ts
+++ b/apps/cli/test/integration/commands/list-json-error.test.ts
@@ -87,6 +87,63 @@ function captureStdout(): { lines: string[]; restore: () => void } {
   return { lines, restore: () => spy.mockRestore() };
 }
 
+// The two tests below cover what the helpers above deliberately avoid:
+// build() hardcodes suppressBar, and --all skips the tracked-set filter. Both
+// bugs live in exactly those paths, which is why the suite passed while
+// `list --json` could still emit non-JSON on stdout.
+function buildInteractive(plugin: Plugin, tracked: readonly string[] = []) {
+  return commandsFromManifest(plugin, {
+    exec: new FixtureExecRunner({ fixtures: [], onPath: ['fake'] }),
+    log: { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} },
+    getStore: async () => ({ list: () => [...tracked] }) as unknown as ConfigStore,
+    bar: new StatusBar(),
+    // The real default on a terminal. build() sets true and hides the bug.
+    suppressBar: false,
+    signal: new AbortController().signal,
+  });
+}
+
+describe('list --json keeps stdout machine-readable', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('emits no spinner chatter on stdout when attached to a TTY', async () => {
+    // withSpinner only engages on a TTY, so CI would never catch this.
+    const isTty = Object.getOwnPropertyDescriptor(process.stdout, 'isTTY');
+    Object.defineProperty(process.stdout, 'isTTY', { value: true, configurable: true });
+    const subCmds = buildInteractive(healthyPlugin()).subCommands as SubCommandsDef;
+    const out = captureStdout();
+    try {
+      await runCommand(subCmds.list as CommandDef, { rawArgs: ['--all', '--json'] });
+    } finally {
+      out.restore();
+      if (isTty) Object.defineProperty(process.stdout, 'isTTY', isTty);
+    }
+
+    expect(() => JSON.parse(out.lines.join('\n'))).not.toThrow();
+    expect(out.lines.join('\n')).not.toMatch(/done\./);
+  });
+
+  it('routes the no-tracked-packages notice to stderr, not stdout', async () => {
+    // No --all and an empty tracked set: the notice fires ahead of the JSON.
+    const subCmds = buildInteractive(healthyPlugin(), []).subCommands as SubCommandsDef;
+    const out = captureStdout();
+    const errLines: string[] = [];
+    const errSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation((m?: unknown) => void errLines.push(String(m)));
+    try {
+      await runCommand(subCmds.list as CommandDef, { rawArgs: ['--json'] });
+    } finally {
+      out.restore();
+      errSpy.mockRestore();
+    }
+
+    expect(() => JSON.parse(out.lines.join('\n'))).not.toThrow();
+    expect(out.lines.join('\n')).not.toMatch(/No tracked packages/);
+    expect(errLines.join('\n')).toMatch(/No tracked packages/);
+  });
+});
+
 describe('list --json distinguishes empty from errored (#51)', () => {
   afterEach(() => vi.restoreAllMocks());
 

--- a/apps/cli/test/integration/commands/list-json-error.test.ts
+++ b/apps/cli/test/integration/commands/list-json-error.test.ts
@@ -1,0 +1,115 @@
+import { runCommand } from 'citty';
+import type { CommandDef, SubCommandsDef } from 'citty';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { commandsFromManifest } from '../../../src/commands/from-manifest';
+import type { ConfigStore } from '../../../src/config/store';
+import { FixtureExecRunner } from '../../../src/exec/fixtures';
+import type { Plugin, PluginContext, PluginManifest } from '../../../src/plugins/types';
+import { StatusBar } from '../../../src/ui/status-bar';
+
+// #51(b): a failing `list` query must be distinguishable from an empty one in
+// --json output. On failure the plugin warns via ctx.log.warn and returns [];
+// the command surfaces that as { error, packages } instead of a bare [].
+
+// list() mirrors pnpm's behaviour: on a non-zero query it warns and returns [].
+function failingPlugin(): Plugin {
+  return {
+    manifest: {
+      id: 'fake',
+      displayName: 'Fake',
+      supportedOS: ['darwin'],
+      requires: [],
+      configKeys: ['npm'],
+      capabilities: {
+        list: true,
+        install: false,
+        update: false,
+        add: false,
+        remove: false,
+        outdated: true,
+      },
+    } as PluginManifest,
+    check: async () => {},
+    list: async (ctx: PluginContext) => {
+      ctx.log.warn('fake list -g failed (exit 1): global bin dir not in PATH');
+      return [];
+    },
+  };
+}
+
+// A healthy plugin that returns one package and never warns.
+function healthyPlugin(): Plugin {
+  return {
+    manifest: {
+      id: 'fake',
+      displayName: 'Fake',
+      supportedOS: ['darwin'],
+      requires: [],
+      configKeys: ['npm'],
+      capabilities: {
+        list: true,
+        install: false,
+        update: false,
+        add: false,
+        remove: false,
+        outdated: true,
+      },
+    } as PluginManifest,
+    check: async () => {},
+    list: async () => [
+      {
+        ref: { kind: 'fake', name: 'alpha' },
+        installed: true,
+        installedVersion: '1.0.0',
+        outdated: false,
+      },
+    ],
+  };
+}
+
+// --all → skip the tracked-set filtering (and its store lookup) entirely.
+function build(plugin: Plugin) {
+  return commandsFromManifest(plugin, {
+    exec: new FixtureExecRunner({ fixtures: [], onPath: ['fake'] }),
+    log: { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} },
+    getStore: async () => ({}) as unknown as ConfigStore,
+    bar: new StatusBar(),
+    suppressBar: true,
+    signal: new AbortController().signal,
+  });
+}
+
+function captureStdout(): { lines: string[]; restore: () => void } {
+  const lines: string[] = [];
+  const spy = vi.spyOn(console, 'log').mockImplementation((msg?: unknown) => {
+    lines.push(String(msg));
+  });
+  return { lines, restore: () => spy.mockRestore() };
+}
+
+describe('list --json distinguishes empty from errored (#51)', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('emits { error, packages } when the query fails', async () => {
+    const subCmds = build(failingPlugin()).subCommands as SubCommandsDef;
+    const out = captureStdout();
+    await runCommand(subCmds.list as CommandDef, { rawArgs: ['--all', '--json'] });
+    out.restore();
+
+    const parsed = JSON.parse(out.lines.join('\n')) as { error: string; packages: unknown[] };
+    expect(Array.isArray(parsed)).toBe(false);
+    expect(parsed.error).toMatch(/failed/i);
+    expect(parsed.packages).toEqual([]);
+  });
+
+  it('keeps the bare PackageStatus[] shape when the query succeeds', async () => {
+    const subCmds = build(healthyPlugin()).subCommands as SubCommandsDef;
+    const out = captureStdout();
+    await runCommand(subCmds.list as CommandDef, { rawArgs: ['--all', '--json'] });
+    out.restore();
+
+    const parsed = JSON.parse(out.lines.join('\n')) as unknown[];
+    expect(Array.isArray(parsed)).toBe(true);
+    expect(parsed).toHaveLength(1);
+  });
+});

--- a/apps/cli/test/integration/completions/shellcheck.test.ts
+++ b/apps/cli/test/integration/completions/shellcheck.test.ts
@@ -1,0 +1,33 @@
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, it } from 'vitest';
+import { generateBashCompletions } from '../../../src/completions/bash';
+import { BUILTIN_PLUGINS } from '../../../src/plugins/registry';
+
+// #52: the generated bash completion (including the per-subcommand flag cases)
+// must stay shellcheck-clean. This guards the real shipped output — built from
+// the actual builtin plugins — at the same severity the repo's `pnpm shellcheck`
+// gates on. zsh/fish are dialects shellcheck cannot parse, so only bash is linted.
+
+const hasShellcheck = (() => {
+  try {
+    execFileSync('shellcheck', ['--version'], { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+})();
+
+describe('generated bash completion — shellcheck', () => {
+  it.skipIf(!hasShellcheck)('passes shellcheck --severity=warning', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'macup-completion-'));
+    const file = join(dir, 'macup-completion.bash');
+    writeFileSync(file, generateBashCompletions(BUILTIN_PLUGINS));
+    // Throws (fails the test) on any finding at warning severity or above.
+    execFileSync('shellcheck', ['--shell=bash', '--severity=warning', file], {
+      stdio: 'pipe',
+    });
+  });
+});


### PR DESCRIPTION
Completes the two remaining audit follow-ups (findings A-2/#51 and G-1/#52). The headline of each already shipped on `develop` — the pnpm default-mode warning (`d78fa2d`) and per-subcommand flag emission (`24daf08`) — but one acceptance criterion in each was still unmet. This closes both.

**#51 — `list --json` distinguishes errored from empty (`fix(cli)`)**
- A failed query serialised a bare `PackageStatus[]`, so an errored query emitted `[]`, indistinguishable from a genuinely empty result.
- The `list` handler now captures the query-failure warning the plugin emits via `ctx.log.warn` and, in `--json` mode, emits `{ error, packages }` when one fired — keeping the bare `PackageStatus[]` shape on success (error field only on failure).
- `--json` flag description updated to document both shapes.

**#52 — generated bash completion is shellcheck-clean (`fix(cli)`)**
- The generated bash tripped `SC2034` (unused `prev`) and `SC2207` (`COMPREPLY=( $(compgen …) )`), so "shellcheck passes on generated bash output" didn't hold and nothing tested it.
- Dropped the unused `prev`; added a file-level `# shellcheck disable=SC2207` for the intentional compgen array-split (`mapfile`/`read -a` need bash 4+, macOS ships 3.2).

**Behavioural notes**
- Default (non-JSON) mode still prints the pnpm warning — the wrapped `warn` delegates. Only the plugin's `ctx.log.warn` is captured, so the command layer's "no tracked packages" notice can't be mistaken for a query error.
- Verified end-to-end with a failing `pnpm` shim: `pnpm list --all --json` → `{ "error": "pnpm list -g failed (exit 1): …", "packages": [] }`. Generated bash now passes `shellcheck --severity=warning` at default and warning severity, with `--dry-run` still completing in zsh/bash/fish.
- zsh/fish are dialects shellcheck cannot parse, so only bash is linted (matches `init.test.ts`).

Tests: add `test/integration/commands/list-json-error.test.ts` (2 cases) and `test/integration/completions/shellcheck.test.ts` (1 case, skipped when shellcheck absent). Full CLI suite: 531/531 (2 pty tests skipped in this env).
Lint: clean. Typecheck: clean. Build: ok.

Closes #51.
Closes #52.
