### PR TITLE
ci: exempt release PRs from whole-history prose/commit gates

### DIFF
--- a/.github/workflows/commits.yml
+++ b/.github/workflows/commits.yml
@@ -3,6 +3,11 @@ name: Commit messages
 # Check every commit subject in the PR against Conventional Commits. Self-contained:
 # no external action, no config file. Merge commits are skipped, so this gate fits
 # macup keeping all three merge methods: it validates the commits that actually land.
+#
+# Release PRs (base=main) are exempt: they aggregate commits already validated on
+# their own feature PRs into develop, and replaying the full develop..main range
+# re-flags pre-convention history that cannot be reworded without rewriting develop.
+# The develop-facing PR is the enforcement point; this one only reports.
 
 on:
   pull_request:
@@ -24,6 +29,10 @@ jobs:
           BASE: ${{ github.event.pull_request.base.sha }}
           HEAD: ${{ github.event.pull_request.head.sha }}
         run: |
+          if [ "${{ github.base_ref }}" = "main" ]; then
+            echo "Release PR (base=main): commits already validated on their develop-facing PRs. Skipping."
+            exit 0
+          fi
           pattern='^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\([^)]+\))?!?: .+'
           fail=0
           for sha in $(git rev-list "$BASE..$HEAD"); do

--- a/.github/workflows/writing-style.yml
+++ b/.github/workflows/writing-style.yml
@@ -5,6 +5,10 @@ name: Writing style
 # Warn-tier findings (the word lists, bold bullet leads) annotate the PR but do not block.
 # Only changed files are linted so the legacy prose backlog does not fail the check. Run
 # `pnpm deslop:lint <paths>` locally to reproduce.
+#
+# Release PRs (base=main) are exempt: the diff against main is the whole accumulated
+# develop delta, so it re-lints prose each feature PR already cleared on its own diff.
+# The develop-facing PR is the enforcement point; this one only reports.
 
 on:
   pull_request:
@@ -28,6 +32,10 @@ jobs:
         # config's excluded dirs (passing files explicitly bypasses the
         # deslopper.config.json excludes).
         run: |
+          if [ "${{ github.base_ref }}" = "main" ]; then
+            echo "Release PR (base=main): prose already linted on develop-facing PRs. Skipping."
+            exit 0
+          fi
           pin=$(jq -r '.scripts["deslop:lint"]' package.json | grep -oE '[0-9a-f]{40}')
           files=$(git diff --name-only --diff-filter=ACMR "origin/${{ github.base_ref }}...HEAD" -- '*.md' '*.markdown' '*.mdx' \
             | grep -Ev '(^|/)(node_modules|\.sandcastle|\.github/chatmodes|docs/superpowers|\.worktrees)/' || true)


### PR DESCRIPTION
The **Conventional Commits** and **De-slop** gates re-scan the entire `develop..main` delta on a release PR (like #61), which:

- replays pre-convention commit history that can't be reworded without rewriting `develop`, and
- re-lints prose that each feature PR already cleared on its own incremental diff.

Both now short-circuit to a pass when `github.base_ref == 'main'`. The develop-facing PR remains the real enforcement point, so feature and develop-integration PRs (base=`develop`) are unaffected. Each gate keeps running (reporting green) rather than being skipped, so required-check status still resolves.

Unblocks the release PR #61.