### PR TITLE
fix(cli): stop Add/Remove wiping the tracked list, and surface config errors

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -58,7 +58,7 @@
     "postpack": "rm -f README.md LICENSE.md"
   },
   "dependencies": {
-    "@clack/core": "^1.3.0",
+    "@clack/core": "1.2.0",
     "@clack/prompts": "^1.2.0",
     "citty": "^0.1.6",
     "execa": "^9.6.1",

--- a/apps/cli/src/cli.ts
+++ b/apps/cli/src/cli.ts
@@ -19,7 +19,7 @@
 //   - src/commands/<name>.ts   — each FlagAction + per-plugin subcommand factory
 //   - src/wizard-runner.ts     — interactive default action
 
-import type { ArgsDef } from 'citty';
+import type { ArgsDef, CommandDef } from 'citty';
 import { defineCommand, runMain } from 'citty';
 import { extractVerbosityFlags, findUnknownTopLevelFlags, rewriteFlagAliases } from './cli/argv';
 import { bootstrap } from './cli/bootstrap';
@@ -108,11 +108,54 @@ for (const plugin of deps.registry) {
   });
 }
 
+// citty's runMain catches whatever escapes a command and hands it to
+// consola, which prints the message followed by an internal stack trace.
+// For a MacupError — a condition we diagnosed and worded FOR the user,
+// like an invalid applist — that trace buries the advice under noise and
+// reads like a crash. citty's own CLIError (the escape hatch runMain
+// checks for) isn't exported, so the boundary goes here instead: catch
+// MacupError at each command's edge, print just the message, and set the
+// exit code. Anything else still escapes with its trace intact.
+function withErrorBoundary<A extends ArgsDef>(cmd: CommandDef<A>): CommandDef<A> {
+  const wrapped: CommandDef<A> = { ...cmd };
+  const run = cmd.run;
+  if (typeof run === 'function') {
+    wrapped.run = async (ctx) => {
+      try {
+        return await run(ctx);
+      } catch (err) {
+        if (err instanceof MacupError) {
+          console.error(`error: ${err.message}`);
+          process.exit(err.exitCode);
+        }
+        throw err;
+      }
+    };
+  }
+  // Subcommands run via citty's own dispatch, not the parent's run(), so
+  // the boundary has to reach every node of the tree.
+  const subs = cmd.subCommands;
+  if (subs && typeof subs === 'object') {
+    const wrappedSubs: Record<string, CommandDef> = {};
+    for (const [name, sub] of Object.entries(subs)) {
+      wrappedSubs[name] = withErrorBoundary(sub as CommandDef);
+    }
+    wrapped.subCommands = wrappedSubs;
+  }
+  return wrapped;
+}
+
+// Only the tree citty dispatches gets the boundary. The wizard runs these
+// same commands via its own runCommand() call and reports failures inline
+// so the session survives — routing it through a boundary that exits the
+// process would turn one failed action into a lost session.
 const topLevelSubCommands = {
-  ...pluginSubCommands,
-  outdated: buildOutdatedCommand(deps),
-  check: buildCheckCommand(deps),
-  init: buildInitCommand(),
+  ...Object.fromEntries(
+    Object.entries(pluginSubCommands).map(([name, cmd]) => [name, withErrorBoundary(cmd)]),
+  ),
+  outdated: withErrorBoundary(buildOutdatedCommand(deps)),
+  check: withErrorBoundary(buildCheckCommand(deps)),
+  init: withErrorBoundary(buildInitCommand()),
 };
 
 // Startup: warn for plugins that can't load (missing binaries on the

--- a/apps/cli/src/cli.ts
+++ b/apps/cli/src/cli.ts
@@ -125,8 +125,12 @@ function withErrorBoundary<A extends ArgsDef>(cmd: CommandDef<A>): CommandDef<A>
         return await run(ctx);
       } catch (err) {
         if (err instanceof MacupError) {
+          // Set-and-return, not process.exit(): exit() can truncate a
+          // piped stdout mid-flush, which would be a poor trade on the
+          // one path whose whole job is getting a message to the user.
           console.error(`error: ${err.message}`);
-          process.exit(err.exitCode);
+          process.exitCode = err.exitCode;
+          return;
         }
         throw err;
       }

--- a/apps/cli/src/config/backup.ts
+++ b/apps/cli/src/config/backup.ts
@@ -20,7 +20,7 @@ export interface BackupEntry {
 // Trailing `(?:_\d+)?` matches the collision suffix uniqueBackupPath adds
 // when two same-operation backups land in the same second (C-1), so those
 // extra files still list and restore instead of silently disappearing.
-const BACKUP_FILE_RE =
+export const BACKUP_FILE_RE =
   /^applist_([A-Za-z0-9-]+)_(\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2})(?:_\d+)?\.yaml$/;
 
 /** Second-resolution `YYYY-MM-DD_HH-MM-SS` stamp used in backup filenames. */

--- a/apps/cli/src/config/schema.ts
+++ b/apps/cli/src/config/schema.ts
@@ -53,3 +53,22 @@ export const ApplistSchema = z.object({
 });
 
 export type Applist = z.infer<typeof ApplistSchema>;
+
+// Renders a zod path as the dotted/indexed form the user actually sees in
+// applist.yaml: ['brew','casks',0] -> `brew.casks[0]`.
+function formatPath(path: ReadonlyArray<PropertyKey>): string {
+  if (path.length === 0) return '(root)';
+  return path.reduce<string>((acc, seg) => {
+    if (typeof seg === 'number') return `${acc}[${seg}]`;
+    return acc === '' ? String(seg) : `${acc}.${String(seg)}`;
+  }, '');
+}
+
+/**
+ * One human-readable line per problem. `ZodError.message` is a JSON dump
+ * of every issue — accurate, but it buries the one thing the user needs
+ * (which line of their YAML is wrong) in ~10 lines of machine output.
+ */
+export function formatApplistIssues(error: z.ZodError): string {
+  return error.issues.map((issue) => `${formatPath(issue.path)}: ${issue.message}`).join('\n');
+}

--- a/apps/cli/src/config/store.ts
+++ b/apps/cli/src/config/store.ts
@@ -3,7 +3,7 @@ import { join } from 'node:path';
 import { type Document, Scalar, YAMLMap, YAMLSeq, parseDocument } from 'yaml';
 import { ErrInvalidConfig } from '../errors';
 import type { SelectionPolicy } from '../plugins/selection';
-import { uniqueBackupPath } from './backup';
+import { BACKUP_FILE_RE, uniqueBackupPath } from './backup';
 import {
   type ApplistKey,
   ApplistSchema,
@@ -270,7 +270,10 @@ export class ConfigStore {
   // copies. Only offered when a backup actually exists.
   private async recoveryHint(): Promise<string> {
     try {
-      const files = (await readdir(this.paths.backupDir)).filter((f) => f.endsWith('.yaml'));
+      // Match on what `macup restore` can actually offer — the same
+      // pattern BackupStore lists by. Counting every *.yaml would promise
+      // a rollback to files restore never shows.
+      const files = (await readdir(this.paths.backupDir)).filter((f) => BACKUP_FILE_RE.test(f));
       if (files.length === 0) return '';
       return `\n\nA backup of this file exists (${files.length} in ${this.paths.backupDir}).\nRun \`macup restore\` to roll back to a working version.`;
     } catch {

--- a/apps/cli/src/config/store.ts
+++ b/apps/cli/src/config/store.ts
@@ -1,10 +1,16 @@
-import { copyFile, mkdir, readFile, rename, writeFile } from 'node:fs/promises';
+import { copyFile, mkdir, readFile, readdir, rename, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { type Document, Scalar, YAMLMap, YAMLSeq, parseDocument } from 'yaml';
 import { ErrInvalidConfig } from '../errors';
 import type { SelectionPolicy } from '../plugins/selection';
 import { uniqueBackupPath } from './backup';
-import { type ApplistKey, ApplistSchema, INITIAL_SCHEMA_VERSION, SCHEMA_VERSION } from './schema';
+import {
+  type ApplistKey,
+  ApplistSchema,
+  INITIAL_SCHEMA_VERSION,
+  SCHEMA_VERSION,
+  formatApplistIssues,
+} from './schema';
 
 export interface ConfigStorePaths {
   readonly applistPath: string;
@@ -210,9 +216,12 @@ export class ConfigStore {
       // rewritten and is now invalid. Surface the backup path so the user
       // can recover, even if they didn't know a migration was happening.
       const suffix = result.migrationBackupPath
-        ? ` (auto-migration ran; original saved to ${result.migrationBackupPath})`
+        ? `\n\nAn auto-migration ran; your original was saved to ${result.migrationBackupPath}`
         : '';
-      throw new ErrInvalidConfig(this.paths.applistPath, parsed.error.message + suffix);
+      throw new ErrInvalidConfig(
+        this.paths.applistPath,
+        `${formatApplistIssues(parsed.error)}${suffix}${await this.recoveryHint()}`,
+      );
     }
 
     // A file declaring a higher version was written by a newer macup whose
@@ -253,6 +262,21 @@ export class ConfigStore {
   // identically. `operation` is the bare label (e.g. 'add', 'migration').
   private uniqueBackupPath(operation: string): string {
     return uniqueBackupPath(this.paths.backupDir, operation, this.now());
+  }
+
+  // An invalid config is nearly always recoverable — every mutation takes
+  // a backup first — but the raw validation error never said so, leaving
+  // the user staring at a zod dump next to a directory full of good
+  // copies. Only offered when a backup actually exists.
+  private async recoveryHint(): Promise<string> {
+    try {
+      const files = (await readdir(this.paths.backupDir)).filter((f) => f.endsWith('.yaml'));
+      if (files.length === 0) return '';
+      return `\n\nA backup of this file exists (${files.length} in ${this.paths.backupDir}).\nRun \`macup restore\` to roll back to a working version.`;
+    } catch {
+      // No backup dir at all — nothing to suggest.
+      return '';
+    }
   }
 
   list(key: ApplistKey): readonly string[] {
@@ -391,6 +415,22 @@ export class ConfigStore {
     const newText = doc.toString();
     if (newText === this.originalText) {
       return { changed: false };
+    }
+    // Validate on the way OUT, not just on the way in. load() rejects a
+    // bad file, but nothing stopped a bad in-memory mutation from being
+    // written — so a caller that staged a non-string name (e.g. an
+    // `undefined` from a mis-typed prompt result) serialized it to a YAML
+    // null, silently replaced the user's list, and only surfaced on the
+    // NEXT load, once the good data was already overwritten. Refusing here
+    // keeps the file on disk intact and blames the mutation, not the file.
+    const parsed = ApplistSchema.safeParse(doc.toJS() ?? {});
+    if (!parsed.success) {
+      throw new ErrInvalidConfig(
+        this.paths.applistPath,
+        `refusing to write an invalid config (${operation}) — your file on disk is unchanged:\n${formatApplistIssues(
+          parsed.error,
+        )}`,
+      );
     }
     await mkdir(this.paths.backupDir, { recursive: true });
     // First-run save has nothing to back up — copyFile would ENOENT and

--- a/apps/cli/src/ui/pageable-prompt.ts
+++ b/apps/cli/src/ui/pageable-prompt.ts
@@ -22,6 +22,15 @@ export interface PageableAutocompleteOptions<T extends OptionLike> extends Autoc
 }
 
 /**
+ * Subclassing AutocompletePrompt means we import `@clack/core` directly
+ * while also using `@clack/prompts`. `@clack/prompts` pins core to an
+ * EXACT version, so any other range here resolves a SECOND copy of core
+ * — and core's cancel sentinel is `Symbol('clack:cancel')`, a unique
+ * symbol per copy. `isCancel()` from `@clack/prompts` then silently
+ * returns false for a cancel raised by our prompt, and the cancel
+ * sentinel leaks downstream as if it were a real answer. Keep the
+ * `@clack/core` dependency pinned to whatever `@clack/prompts` pins.
+ *
  * AutocompletePrompt with multi-row PgUp/PgDn navigation. Clack 1.2's
  * action set is hardcoded (up/down/left/right/space/enter/cancel), so
  * page navigation isn't a first-class action — but each up/down step

--- a/apps/cli/src/ui/picker.ts
+++ b/apps/cli/src/ui/picker.ts
@@ -1,3 +1,4 @@
+import type { Readable, Writable } from 'node:stream';
 import {
   S_BAR,
   S_BAR_END,
@@ -30,6 +31,12 @@ export interface PickerOptions<Value> {
   required?: boolean;
   /** Visible-window size; also used as the page-step for PgUp/PgDn. */
   maxItems?: number;
+  /**
+   * Streams to drive the prompt with. Default to the real terminal;
+   * tests pass mocks to exercise the prompt without a TTY.
+   */
+  input?: Readable;
+  output?: Writable;
 }
 
 const opt = (
@@ -186,6 +193,12 @@ export async function pageableAutocompleteMultiselect<Value>(
   // time PgUp/PgDn fires, this is populated.
   let layout: GridLayout = { cols: 1, rowsPerCol, pageItems: rowsPerCol };
 
+  // clack tracks selection as VALUES, not options (see the submit render
+  // and the return below), so rendering a picked row's label means
+  // resolving the value back to its option.
+  const byValue = new Map(opts.options.map((o) => [o.value, o]));
+  const toOption = (value: Value): PickerOption<Value> => byValue.get(value) ?? { value };
+
   const prompt: PageableAutocompletePrompt<PickerOption<Value>> = new PageableAutocompletePrompt<
     PickerOption<Value>
   >({
@@ -193,6 +206,8 @@ export async function pageableAutocompleteMultiselect<Value>(
     multiple: true,
     initialValue: opts.initialValues ? [...opts.initialValues] : undefined,
     pageStep: () => layout.pageItems,
+    ...(opts.input ? { input: opts.input } : {}),
+    ...(opts.output ? { output: opts.output } : {}),
     validate(value) {
       if (required && (value === undefined || (Array.isArray(value) && value.length === 0))) {
         return `Please select at least one option.\n${pc.reset(
@@ -221,7 +236,7 @@ export async function pageableAutocompleteMultiselect<Value>(
       // Cancellation / submission render: collapse to the picked rows
       // (or strikethrough on cancel), matching clack's stock behavior.
       if (this.state === 'submit') {
-        const selected = (this.value as PickerOption<Value>[] | undefined) ?? [];
+        const selected = this.selectedValues.map(toOption);
         return `${titleLine}${pc.gray(S_BAR)}  ${
           selected.length > 0
             ? selected.map((o) => opt(o, 'submitted')).join(pc.dim(', '))
@@ -229,7 +244,7 @@ export async function pageableAutocompleteMultiselect<Value>(
         }`;
       }
       if (this.state === 'cancel') {
-        const selected = (this.value as PickerOption<Value>[] | undefined) ?? [];
+        const selected = this.selectedValues.map(toOption);
         return `${titleLine}${pc.gray(S_BAR)}  ${
           selected.length > 0 ? selected.map((o) => opt(o, 'cancelled')).join(pc.dim(', ')) : ''
         }${selected.length > 0 ? `\n${pc.gray(S_BAR)}` : ''}`;
@@ -261,8 +276,11 @@ export async function pageableAutocompleteMultiselect<Value>(
 
   const resolved = await prompt.prompt();
   if (clackIsCancel(resolved)) return resolved;
-  const arr = (resolved as PickerOption<Value>[] | undefined) ?? [];
-  return arr.map((o) => o.value);
+  // `multiple: true` resolves to the selected VALUES, not the option
+  // objects — AutocompletePrompt extends Prompt<T['value'] | T['value'][]>
+  // and submit assigns from `selectedValues`. Reading `.value` off these
+  // yields undefined, which the ConfigStore then writes as a YAML null.
+  return (resolved as Value[] | undefined) ?? [];
 }
 
 /**
@@ -283,6 +301,8 @@ export async function pageableSelect<Value>(
     multiple: false,
     initialValue: opts.initialValue !== undefined ? [opts.initialValue] : undefined,
     pageStep: () => layout.pageItems,
+    ...(opts.input ? { input: opts.input } : {}),
+    ...(opts.output ? { output: opts.output } : {}),
     render(this: PageableAutocompletePrompt<PickerOption<Value>>) {
       layout = gridLayout(this.filteredOptions, rowsPerCol, process.stdout.columns ?? 80);
 
@@ -319,8 +339,9 @@ export async function pageableSelect<Value>(
 
   const resolved = await prompt.prompt();
   if (clackIsCancel(resolved)) return resolved;
-  const arr = resolved as PickerOption<Value>[] | undefined;
-  return (arr?.[0]?.value ?? undefined) as Value;
+  // `multiple: false` resolves to a single VALUE (clack normalises
+  // `selectedValues[0]`), not an option object.
+  return resolved as Value;
 }
 
 function getStepSymbol(state: string): string {

--- a/apps/cli/src/ui/picker.ts
+++ b/apps/cli/src/ui/picker.ts
@@ -39,6 +39,18 @@ export interface PickerOptions<Value> {
   output?: Writable;
 }
 
+// Forwards only the streams the caller actually set, so clack keeps its
+// own process.stdin/stdout defaults when they're absent.
+function streamOpts(opts: {
+  input?: Readable;
+  output?: Writable;
+}): { input?: Readable; output?: Writable } {
+  return {
+    ...(opts.input ? { input: opts.input } : {}),
+    ...(opts.output ? { output: opts.output } : {}),
+  };
+}
+
 const opt = (
   option: PickerOption<unknown>,
   state: 'inactive' | 'active' | 'selected' | 'active-selected' | 'submitted' | 'cancelled',
@@ -206,8 +218,7 @@ export async function pageableAutocompleteMultiselect<Value>(
     multiple: true,
     initialValue: opts.initialValues ? [...opts.initialValues] : undefined,
     pageStep: () => layout.pageItems,
-    ...(opts.input ? { input: opts.input } : {}),
-    ...(opts.output ? { output: opts.output } : {}),
+    ...streamOpts(opts),
     validate(value) {
       if (required && (value === undefined || (Array.isArray(value) && value.length === 0))) {
         return `Please select at least one option.\n${pc.reset(
@@ -235,19 +246,19 @@ export async function pageableAutocompleteMultiselect<Value>(
 
       // Cancellation / submission render: collapse to the picked rows
       // (or strikethrough on cancel), matching clack's stock behavior.
-      if (this.state === 'submit') {
-        const selected = this.selectedValues.map(toOption);
+      if (this.state === 'submit' || this.state === 'cancel') {
+        const picked = this.selectedValues.map(toOption);
+        const rows = picked
+          .map((o) => opt(o, this.state === 'submit' ? 'submitted' : 'cancelled'))
+          .join(pc.dim(', '));
+        if (this.state === 'submit') {
+          return `${titleLine}${pc.gray(S_BAR)}  ${picked.length > 0 ? rows : pc.dim('(none)')}`;
+        }
+        // Cancelling with nothing picked leaves no row to strike through,
+        // so the trailing bar would frame an empty line.
         return `${titleLine}${pc.gray(S_BAR)}  ${
-          selected.length > 0
-            ? selected.map((o) => opt(o, 'submitted')).join(pc.dim(', '))
-            : pc.dim('(none)')
+          picked.length > 0 ? `${rows}\n${pc.gray(S_BAR)}` : ''
         }`;
-      }
-      if (this.state === 'cancel') {
-        const selected = this.selectedValues.map(toOption);
-        return `${titleLine}${pc.gray(S_BAR)}  ${
-          selected.length > 0 ? selected.map((o) => opt(o, 'cancelled')).join(pc.dim(', ')) : ''
-        }${selected.length > 0 ? `\n${pc.gray(S_BAR)}` : ''}`;
       }
 
       // Active render: filter input + visible grid of options.
@@ -301,8 +312,7 @@ export async function pageableSelect<Value>(
     multiple: false,
     initialValue: opts.initialValue !== undefined ? [opts.initialValue] : undefined,
     pageStep: () => layout.pageItems,
-    ...(opts.input ? { input: opts.input } : {}),
-    ...(opts.output ? { output: opts.output } : {}),
+    ...streamOpts(opts),
     render(this: PageableAutocompletePrompt<PickerOption<Value>>) {
       layout = gridLayout(this.filteredOptions, rowsPerCol, process.stdout.columns ?? 80);
 

--- a/apps/cli/src/wizard-runner.ts
+++ b/apps/cli/src/wizard-runner.ts
@@ -20,7 +20,7 @@ import * as logui from './ui/log';
 import { renderAppleLogo } from './ui/logo';
 import { pageableAutocompleteMultiselect } from './ui/picker';
 import { getVersion } from './version';
-import { type ActionResult, type Target, pickAction, pickTarget } from './wizard';
+import { type ActionResult, type Target, type WizardDeps, pickAction, pickTarget } from './wizard';
 
 // Cap clack's autocompleteMultiselect window to a sensible fraction of
 // the terminal height so the user can still see the prompt header and
@@ -296,6 +296,32 @@ async function applySyncTracked(
   console.log(`\n${logui.header('TRACKED')} ${parts.join(' ')}`);
 }
 
+// Sentinel for "a prompt threw" — distinct from `null`, which is the
+// user deliberately hitting Esc.
+export const PICKER_FAILED = Symbol('picker-failed');
+
+/**
+ * Error boundary around the interactive pickers. A throw inside a prompt
+ * used to escape runWizard → runMain and kill the whole session with a
+ * raw stack trace, losing the user's place (and, for a TTY prompt, often
+ * leaving the terminal mid-render). An unexpected prompt failure is a
+ * bug, but it should cost the user one submenu, not the session — so it
+ * is reported and unwound to the plugin picker.
+ */
+export async function pickActionSafely(
+  wizardDeps: WizardDeps,
+  target: Target,
+): Promise<ActionResult | null | typeof PICKER_FAILED> {
+  try {
+    return await pickAction(wizardDeps, target);
+  } catch (err) {
+    const label = target.subtype ? `${target.pluginId}:${target.subtype}` : target.pluginId;
+    console.error(`\nerror: the ${label} menu failed unexpectedly — returning to the plugin list.`);
+    console.error(`  ↳ ${err instanceof Error ? err.message : String(err)}`);
+    return PICKER_FAILED;
+  }
+}
+
 export async function runWizard(
   deps: CliDeps,
   pluginSubCommands: Record<string, CommandDef>,
@@ -363,7 +389,7 @@ export async function runWizard(
 
     // Inner loop: keep showing the submenu until the user hits Esc.
     while (true) {
-      const result: ActionResult | null = await pickAction(
+      const result: ActionResult | null | typeof PICKER_FAILED = await pickActionSafely(
         {
           plugins: deps.registry,
           selectTarget: async () => null, // unused at the action stage
@@ -447,6 +473,9 @@ export async function runWizard(
         target,
       );
 
+      // A failed picker unwinds to the plugin list, same as Esc — but the
+      // reason was already reported, so don't swallow it silently.
+      if (result === PICKER_FAILED) break;
       if (!result) break; // Esc at submenu → back to pickTarget.
 
       if (result.kind === 'sync-tracked') {

--- a/apps/cli/src/wizard-runner.ts
+++ b/apps/cli/src/wizard-runner.ts
@@ -300,10 +300,18 @@ async function applySyncTracked(
 // user deliberately hitting Esc.
 export const PICKER_FAILED = Symbol('picker-failed');
 
+// Both boundaries below report the same way: name what broke and where the
+// user lands, then the cause. Never swallow the cause — a bug that unwinds
+// silently is a bug nobody reports.
+function reportPickerFailure(what: string, unwindsTo: string, err: unknown): void {
+  console.error(`\n${logui.error(`The ${what} failed — ${unwindsTo}.`)}`);
+  console.error(logui.traceError(err instanceof Error ? err.message : String(err)));
+}
+
 /**
- * Error boundary around the interactive pickers. A throw inside a prompt
- * used to escape runWizard → runMain and kill the whole session with a
- * raw stack trace, losing the user's place (and, for a TTY prompt, often
+ * Error boundary around the action submenu. A throw inside a prompt used
+ * to escape runWizard → runMain and kill the whole session with a raw
+ * stack trace, losing the user's place (and, for a TTY prompt, often
  * leaving the terminal mid-render). An unexpected prompt failure is a
  * bug, but it should cost the user one submenu, not the session — so it
  * is reported and unwound to the plugin picker.
@@ -316,9 +324,25 @@ export async function pickActionSafely(
     return await pickAction(wizardDeps, target);
   } catch (err) {
     const label = target.subtype ? `${target.pluginId}:${target.subtype}` : target.pluginId;
-    console.error(`\nerror: the ${label} menu failed unexpectedly — returning to the plugin list.`);
-    console.error(`  ↳ ${err instanceof Error ? err.message : String(err)}`);
+    reportPickerFailure(`${label} menu`, 'returning to the plugin list', err);
     return PICKER_FAILED;
+  }
+}
+
+/**
+ * The same boundary for the outer picker. It runs the same prompt module
+ * over the same clack coupling, so guarding only the submenu would leave
+ * the identical crash live one screen earlier. There's nowhere further
+ * back to unwind to, so this ends the wizard — but on our terms, with the
+ * cause reported and a failing exit code, rather than a raw trace.
+ */
+async function pickTargetSafely(wizardDeps: WizardDeps): Promise<Target | null> {
+  try {
+    return await pickTarget(wizardDeps);
+  } catch (err) {
+    reportPickerFailure('plugin list', 'leaving the wizard', err);
+    process.exitCode = 1;
+    return null;
   }
 }
 
@@ -349,7 +373,7 @@ export async function runWizard(
   //   outer: pickTarget → choose category (or Esc to exit)
   //   inner: pickAction → choose action, execute, repeat (Esc → outer)
   while (true) {
-    const target = await pickTarget({
+    const target = await pickTargetSafely({
       plugins: deps.registry,
       selectTarget: async (groups) => {
         // Single-pick `select` with disabled "header" rows for category

--- a/apps/cli/test/integration/config/store.test.ts
+++ b/apps/cli/test/integration/config/store.test.ts
@@ -218,9 +218,9 @@ describe('ConfigStore — legacy layout migration', () => {
     // migration backup so the user can recover their original file.
     await seed('npm_apps: not-a-list\n');
     const s = new ConfigStore({ applistPath, backupDir });
-    await expect(s.load()).rejects.toThrow(
-      /auto-migration ran; original saved to .*applist_migration_/,
-    );
+    // Matches the intent, not the exact prose: the path is what the user
+    // needs, so pin that rather than the sentence wrapped around it.
+    await expect(s.load()).rejects.toThrow(/auto-migration ran.*applist_migration_/);
   });
 
   it('migrates flat keys to nested layout on load and writes a migration backup', async () => {

--- a/apps/cli/test/regression/config-errors-are-actionable.test.ts
+++ b/apps/cli/test/regression/config-errors-are-actionable.test.ts
@@ -12,6 +12,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { ConfigStore } from '../../src/config/store';
+import { ErrInvalidConfig } from '../../src/errors';
 
 let workDir: string;
 let applistPath: string;
@@ -43,6 +44,13 @@ async function loadCorrupt(): Promise<Error> {
 }
 
 describe('regression: an invalid config names the offending key', () => {
+  it('fails as ErrInvalidConfig with a failing exit code', async () => {
+    const err = await loadCorrupt();
+
+    expect(err).toBeInstanceOf(ErrInvalidConfig);
+    expect((err as ErrInvalidConfig).exitCode).toBe(1);
+  });
+
   it('reports the YAML path, not a JSON dump of zod issues', async () => {
     const err = await loadCorrupt();
 

--- a/apps/cli/test/regression/config-errors-are-actionable.test.ts
+++ b/apps/cli/test/regression/config-errors-are-actionable.test.ts
@@ -1,0 +1,76 @@
+// Regression guard: an invalid config must explain itself.
+//
+// When the Add/Remove bug wrote a YAML `null` into brew.casks, every
+// later run died with `ZodError.message` — a ~12-line JSON dump of the
+// raw issue objects. It was accurate and nearly useless: it never named
+// the file's offending line in the form the user reads, and never
+// mentioned that a directory of good backups (and `macup restore`) was
+// sitting right next to it.
+
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { ConfigStore } from '../../src/config/store';
+
+let workDir: string;
+let applistPath: string;
+let backupDir: string;
+
+// The exact corruption the picker bug produced.
+const CORRUPT = '---\nbrew:\n  casks:\n    - null\n';
+const VALID = "---\nbrew:\n  casks:\n    - 'warp'\n";
+
+beforeEach(async () => {
+  workDir = await mkdtemp(join(tmpdir(), 'macup-cfg-err-'));
+  applistPath = join(workDir, 'applist.yaml');
+  backupDir = join(workDir, 'backups');
+});
+
+afterEach(async () => {
+  await rm(workDir, { recursive: true, force: true });
+});
+
+async function loadCorrupt(): Promise<Error> {
+  await writeFile(applistPath, CORRUPT, 'utf8');
+  const s = new ConfigStore({ applistPath, backupDir });
+  return await s.load().then(
+    () => {
+      throw new Error('expected load() to reject');
+    },
+    (err: Error) => err,
+  );
+}
+
+describe('regression: an invalid config names the offending key', () => {
+  it('reports the YAML path, not a JSON dump of zod issues', async () => {
+    const err = await loadCorrupt();
+
+    expect(err.message).toContain('brew.casks[0]');
+    expect(err.message).toContain('expected string, received null');
+    // The old message was raw ZodError JSON — these are its fingerprints.
+    expect(err.message).not.toContain('"code"');
+    expect(err.message).not.toContain('"invalid_type"');
+  });
+});
+
+describe('regression: an invalid config points at recovery', () => {
+  it('suggests `macup restore` when a backup exists', async () => {
+    await mkdir(backupDir, { recursive: true });
+    await writeFile(join(backupDir, 'applist_add_2026-01-01_00-00-00.yaml'), VALID, 'utf8');
+
+    const err = await loadCorrupt();
+
+    expect(err.message).toContain('macup restore');
+    expect(err.message).toContain(backupDir);
+  });
+
+  it('stays quiet about restore when there is nothing to restore', async () => {
+    // No backup dir at all — suggesting a rollback here would send the
+    // user chasing a command that cannot help them.
+    const err = await loadCorrupt();
+
+    expect(err.message).toContain('brew.casks[0]');
+    expect(err.message).not.toContain('macup restore');
+  });
+});

--- a/apps/cli/test/regression/picker-returns-values.test.ts
+++ b/apps/cli/test/regression/picker-returns-values.test.ts
@@ -1,0 +1,133 @@
+// Regression guard for the Add/Remove data-loss bug.
+//
+// `pageableAutocompleteMultiselect` used to cast clack's resolved value
+// to `PickerOption[]` and read `.value` off each entry. But clack
+// resolves the selected VALUES, not the option objects, so every pick
+// came back `undefined`. Those undefineds flowed into ConfigStore.add,
+// serialized as a YAML `null`, and replaced the user's tracked list —
+// wiping 38 casks in one keystroke and leaving a config that no longer
+// parsed on load.
+//
+// The unit tests missed it because the wizard's seam (`WizardDeps
+// .pickTrackedSet`) is stubbed with hand-written string arrays, and the
+// ConfigStore tests feed it hand-written string arrays too. Both sides
+// of the bridge were tested; the bridge itself was not. These tests
+// drive the REAL prompt over mock streams so the values are the
+// prompt's, not the test's.
+
+import type { EventEmitter } from 'node:events';
+import { Readable, Writable } from 'node:stream';
+import { isCancel as promptsIsCancel } from '@clack/prompts';
+import { describe, expect, it } from 'vitest';
+import { pageableAutocompleteMultiselect } from '../../src/ui/picker';
+
+// clack drives the prompt off readline 'keypress' events on `input` and
+// needs a TTY-shaped stream. Emitting 'keypress' directly is exactly
+// what readline would do for a real keystroke.
+class MockReadable extends Readable {
+  isTTY = true;
+  setRawMode(): this {
+    return this;
+  }
+  override _read() {}
+}
+
+class MockWritable extends Writable {
+  isTTY = true;
+  columns = 120;
+  rows = 30;
+  override _write(_c: unknown, _e: unknown, cb: () => void) {
+    cb();
+  }
+}
+
+function press(input: MockReadable, name: string, char = ''): void {
+  (input as unknown as EventEmitter).emit('keypress', char, {
+    name,
+    sequence: char,
+    ctrl: false,
+    meta: false,
+    shift: false,
+  });
+}
+
+const OPTIONS = [
+  { label: 'warp', value: 'warp' },
+  { label: 'iterm2', value: 'iterm2' },
+  { label: 'docker', value: 'docker' },
+];
+
+function startPicker(input: MockReadable, output: MockWritable, initialValues?: string[]) {
+  return pageableAutocompleteMultiselect<string>({
+    message: 'Tracked packages',
+    options: OPTIONS,
+    required: false,
+    ...(initialValues ? { initialValues } : {}),
+    input,
+    output,
+  });
+}
+
+// The picker subclasses `@clack/core`'s AutocompletePrompt while the
+// callers test cancellation with `isCancel` from `@clack/prompts`. Core's
+// cancel sentinel is a unique `Symbol('clack:cancel')`, so if the two
+// packages ever resolve DIFFERENT copies of core, this check silently
+// returns false and the sentinel is mistaken for a real answer — which
+// is what produced `TypeError: arr.map is not a function` on Esc.
+// Asserting through `@clack/prompts` (the caller's import, not core's)
+// is what makes this test able to see the split.
+describe('regression: a cancelled picker is recognised as cancelled', () => {
+  it('resolves a sentinel that @clack/prompts isCancel accepts', async () => {
+    const input = new MockReadable();
+    const promise = startPicker(input, new MockWritable());
+
+    press(input, 'escape');
+
+    const result = await promise;
+    expect(promptsIsCancel(result)).toBe(true);
+  });
+});
+
+describe('regression: picker resolves package names, not undefined', () => {
+  it('returns the selected values — never undefined', async () => {
+    const input = new MockReadable();
+    const promise = startPicker(input, new MockWritable());
+
+    // Space only toggles once the prompt is navigating (clack gates it on
+    // `isNavigating` so a space can still be typed into the filter).
+    press(input, 'down'); // focus iterm2
+    press(input, 'space', ' ');
+    press(input, 'return');
+
+    const result = await promise;
+    expect(result).toEqual(['iterm2']);
+    // The precise shape of the bug: a name-shaped hole that YAML writes
+    // as `null` and the applist schema then rejects on the next load.
+    expect(result).not.toContain(undefined);
+  });
+
+  it('preserves pre-selected tracked names when submitted untouched', async () => {
+    const input = new MockReadable();
+    const promise = startPicker(input, new MockWritable(), ['warp', 'iterm2']);
+
+    press(input, 'return'); // submit without changing anything
+
+    // A no-op Add/Remove must round-trip the tracked set intact. Under
+    // the bug this returned [undefined, undefined], which diffed to
+    // "remove everything, add null".
+    expect(await promise).toEqual(['warp', 'iterm2']);
+  });
+
+  it('returns every selected value, in a multi-pick', async () => {
+    const input = new MockReadable();
+    const promise = startPicker(input, new MockWritable());
+
+    press(input, 'down'); // focus iterm2
+    press(input, 'space', ' ');
+    press(input, 'down'); // focus docker
+    press(input, 'space', ' ');
+    press(input, 'return');
+
+    expect(await promise).toEqual(['iterm2', 'docker']);
+  });
+});

--- a/apps/cli/test/regression/picker-returns-values.test.ts
+++ b/apps/cli/test/regression/picker-returns-values.test.ts
@@ -19,7 +19,7 @@ import type { EventEmitter } from 'node:events';
 import { Readable, Writable } from 'node:stream';
 import { isCancel as promptsIsCancel } from '@clack/prompts';
 import { describe, expect, it } from 'vitest';
-import { pageableAutocompleteMultiselect } from '../../src/ui/picker';
+import { pageableAutocompleteMultiselect, pageableSelect } from '../../src/ui/picker';
 
 // clack drives the prompt off readline 'keypress' events on `input` and
 // needs a TTY-shaped stream. Emitting 'keypress' directly is exactly
@@ -67,6 +67,26 @@ function startPicker(input: MockReadable, output: MockWritable, initialValues?: 
     output,
   });
 }
+
+// pageableSelect carried the identical cast, and would have handed its
+// first caller `undefined` the same way. It has no caller yet, so this is
+// the only thing keeping the fix honest.
+describe('regression: the single-select picker resolves a value too', () => {
+  it('returns the focused value, not undefined', async () => {
+    const input = new MockReadable();
+    const promise = pageableSelect<string>({
+      message: 'Pick one',
+      options: OPTIONS,
+      input,
+      output: new MockWritable(),
+    });
+
+    press(input, 'down'); // focus iterm2
+    press(input, 'return');
+
+    expect(await promise).toBe('iterm2');
+  });
+});
 
 // The picker subclasses `@clack/core`'s AutocompletePrompt while the
 // callers test cancellation with `isCancel` from `@clack/prompts`. Core's

--- a/apps/cli/test/regression/save-rejects-invalid-config.test.ts
+++ b/apps/cli/test/regression/save-rejects-invalid-config.test.ts
@@ -44,7 +44,21 @@ describe('regression: save refuses to write an invalid config', () => {
     // Exactly what the broken picker handed the store.
     s.add('brew.casks', [undefined as unknown as string]);
 
-    await expect(s.save('sync-tracked')).rejects.toBeInstanceOf(ErrInvalidConfig);
+    const err = await s.save('sync-tracked').then(
+      () => {
+        throw new Error('expected save() to reject');
+      },
+      (e: Error) => e,
+    );
+
+    expect(err).toBeInstanceOf(ErrInvalidConfig);
+    expect((err as ErrInvalidConfig).exitCode).toBe(1);
+    // Appended after the two seeded casks, and still `undefined` here —
+    // it only becomes the YAML `null` of the load-side error once written,
+    // which is the write this refuses.
+    expect(err.message).toContain(
+      'brew.casks[2]: Invalid input: expected string, received undefined',
+    );
   });
 
   it('leaves the on-disk list intact when the save is refused', async () => {

--- a/apps/cli/test/regression/save-rejects-invalid-config.test.ts
+++ b/apps/cli/test/regression/save-rejects-invalid-config.test.ts
@@ -1,0 +1,75 @@
+// Regression guard: save() must not write a config it would refuse to
+// load. The Add/Remove data-loss bug staged `undefined` package names
+// (see picker-returns-values.test.ts); ConfigStore serialized them as a
+// YAML `null` and overwrote the user's tracked list. Nothing objected
+// until the NEXT load, by which point the good data was gone — the
+// validation was strict on the way in and absent on the way out.
+//
+// These tests pin the symmetry: a bad mutation fails loudly at save
+// time, with the on-disk file untouched.
+
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { ConfigStore } from '../../src/config/store';
+import { ErrInvalidConfig } from '../../src/errors';
+
+let workDir: string;
+let applistPath: string;
+let backupDir: string;
+
+const SEED = "---\nbrew:\n  casks:\n    - 'warp'\n    - 'iterm2'\n";
+
+beforeEach(async () => {
+  workDir = await mkdtemp(join(tmpdir(), 'macup-save-guard-'));
+  applistPath = join(workDir, 'applist.yaml');
+  backupDir = join(workDir, 'backups');
+  await writeFile(applistPath, SEED, 'utf8');
+});
+
+afterEach(async () => {
+  await rm(workDir, { recursive: true, force: true });
+});
+
+async function store(): Promise<ConfigStore> {
+  const s = new ConfigStore({ applistPath, backupDir });
+  await s.load();
+  return s;
+}
+
+describe('regression: save refuses to write an invalid config', () => {
+  it('throws rather than serializing a non-string name as null', async () => {
+    const s = await store();
+    // Exactly what the broken picker handed the store.
+    s.add('brew.casks', [undefined as unknown as string]);
+
+    await expect(s.save('sync-tracked')).rejects.toBeInstanceOf(ErrInvalidConfig);
+  });
+
+  it('leaves the on-disk list intact when the save is refused', async () => {
+    const s = await store();
+    // The full shape of the data loss: drop every real name, add a hole.
+    s.remove('brew.casks', ['warp', 'iterm2']);
+    s.add('brew.casks', [undefined as unknown as string]);
+
+    await expect(s.save('sync-tracked')).rejects.toThrow();
+
+    // The user's casks must still be on disk — the whole point of
+    // failing before the write rather than after it.
+    const onDisk = await readFile(applistPath, 'utf8');
+    expect(onDisk).toContain('warp');
+    expect(onDisk).toContain('iterm2');
+    expect(onDisk).not.toContain('null');
+  });
+
+  it('still saves a valid change', async () => {
+    const s = await store();
+    s.add('brew.casks', ['docker']);
+
+    const result = await s.save('sync-tracked');
+
+    expect(result.changed).toBe(true);
+    expect(await readFile(applistPath, 'utf8')).toContain('docker');
+  });
+});

--- a/apps/cli/test/regression/wizard-survives-picker-crash.test.ts
+++ b/apps/cli/test/regression/wizard-survives-picker-crash.test.ts
@@ -1,0 +1,104 @@
+// Regression guard: a throw inside a prompt must not kill the wizard.
+//
+// `TypeError: arr.map is not a function` escaped the picker, unwound
+// through pickAction → runWizard → runCommand → runMain, and ended the
+// session with a raw stack trace — losing the user's place mid-flow. The
+// crash itself is fixed (see picker-returns-values.test.ts), but the
+// missing boundary is the reason a single prompt bug could take down
+// everything, so pin the boundary too.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Plugin, PluginManifest } from '../../src/plugins/types';
+import type { Target, WizardDeps } from '../../src/wizard';
+import { PICKER_FAILED, pickActionSafely } from '../../src/wizard-runner';
+
+function mkPlugin(id: string): Plugin {
+  return {
+    manifest: {
+      id,
+      displayName: id.toUpperCase(),
+      supportedOS: ['darwin'],
+      requires: [],
+      configKeys: ['brew.casks'],
+      subtypes: ['casks'],
+      capabilities: {
+        list: true,
+        install: true,
+        update: true,
+        add: true,
+        remove: true,
+        outdated: true,
+      },
+    } as unknown as PluginManifest,
+    check: async () => {},
+    list: async () => [],
+  };
+}
+
+const TARGET: Target = { pluginId: 'brew', subtype: 'casks' };
+
+function deps(overrides: Partial<WizardDeps> = {}): WizardDeps {
+  return {
+    plugins: [mkPlugin('brew')],
+    selectTarget: async () => null,
+    selectAction: async () => 'sync-tracked',
+    currentTracked: async () => ['warp'],
+    pickTrackedSet: async () => ['warp'],
+    ...overrides,
+  };
+}
+
+let errorSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  errorSpy.mockRestore();
+});
+
+describe('regression: a crashing picker unwinds instead of killing the wizard', () => {
+  it('returns the sentinel rather than propagating the throw', async () => {
+    const result = await pickActionSafely(
+      deps({
+        pickTrackedSet: async () => {
+          throw new TypeError('arr.map is not a function');
+        },
+      }),
+      TARGET,
+    );
+
+    expect(result).toBe(PICKER_FAILED);
+  });
+
+  it('reports the failure with the underlying cause, not silently', async () => {
+    await pickActionSafely(
+      deps({
+        pickTrackedSet: async () => {
+          throw new TypeError('arr.map is not a function');
+        },
+      }),
+      TARGET,
+    );
+
+    const printed = errorSpy.mock.calls.flat().join('\n');
+    expect(printed).toContain('brew:casks');
+    // Swallowing the cause would leave a bug like this invisible.
+    expect(printed).toContain('arr.map is not a function');
+  });
+
+  it('still passes a normal result straight through', async () => {
+    const result = await pickActionSafely(
+      deps({ pickTrackedSet: async () => ['warp', 'docker'] }),
+      TARGET,
+    );
+
+    expect(result).toEqual({
+      kind: 'sync-tracked',
+      target: TARGET,
+      adds: ['docker'],
+      removes: [],
+    });
+  });
+});

--- a/apps/cli/test/regression/wizard-survives-picker-crash.test.ts
+++ b/apps/cli/test/regression/wizard-survives-picker-crash.test.ts
@@ -88,6 +88,15 @@ describe('regression: a crashing picker unwinds instead of killing the wizard', 
     expect(printed).toContain('arr.map is not a function');
   });
 
+  it('reports the plugin id even when the target has no subtype', async () => {
+    await pickActionSafely(
+      { ...deps({ pickTrackedSet: async () => Promise.reject(new Error('boom')) }) },
+      { pluginId: 'npm' },
+    );
+
+    expect(errorSpy.mock.calls.flat().join('\n')).toContain('npm');
+  });
+
   it('still passes a normal result straight through', async () => {
     const result = await pickActionSafely(
       deps({ pickTrackedSet: async () => ['warp', 'docker'] }),

--- a/docs/adr/0028-clack-core-subclassing-and-pin.md
+++ b/docs/adr/0028-clack-core-subclassing-and-pin.md
@@ -1,0 +1,70 @@
+# ADR 0028: Subclass @clack/core's AutocompletePrompt, and pin core to prompts' version
+
+> Status: accepted · Date: 2026-07-15 · Deciders: John Valai
+
+## Context
+
+The tracked-package picker needs PgUp/PgDn, Home/End and a multi-column grid. `@clack/prompts`
+exposes `autocompleteMultiselect` as a finished prompt with a fixed render and a hardcoded action
+set (up/down/left/right/space/enter/cancel), so none of that is reachable through its public API.
+`@clack/core` exposes the `AutocompletePrompt` class the finished prompt is built from, which does
+allow a subclass to supply its own `render` and to synthesise cursor moves.
+
+`src/ui/pageable-prompt.ts` subclasses it. That is what makes the picker possible, and it also
+creates a coupling that is easy to miss: macup now imports from **both** `@clack/core` and
+`@clack/prompts`, and `@clack/prompts` depends on `@clack/core` at an **exact** version
+(`"@clack/core": "1.2.0"`, not a range).
+
+Two copies of `@clack/core` therefore load whenever macup's own range resolves anything else. They
+do not merely waste bytes. Core's cancel sentinel is a module-local `Symbol('clack:cancel')`, and a
+symbol is unique per copy, so `isCancel()` imported from `@clack/prompts` compares against a
+different sentinel than the one a prompt built on the other copy returns. It answers `false` for a
+genuine cancel, silently, and the sentinel then flows on as if it were the user's answer.
+
+This is not hypothetical. macup depended on `@clack/core: ^1.3.0` while `@clack/prompts@1.2.0`
+pinned `1.2.0`. Cancelling the Add/Remove picker crashed with `TypeError: arr.map is not a
+function`, because the cancel check said "not a cancel" and the caller went on to treat a symbol as
+an array of picks.
+
+## Decision
+
+Keep the subclass, and pin `@clack/core` to the exact version `@clack/prompts` pins. When
+`@clack/prompts` is upgraded, read its `dependencies` and move macup's `@clack/core` pin in
+lockstep, in the same change.
+
+`test/regression/picker-returns-values.test.ts` guards this: it asserts a cancelled picker is
+recognised by `isCancel` **imported from `@clack/prompts`**, which is the caller's import and
+therefore the thing that actually breaks. The test fails if the two ever split again.
+
+## Alternatives
+
+- **Use `autocompleteMultiselect` unmodified.** No second dependency and no pin to maintain, but no
+  paging and no grid. A 290-package list is unusable ten rows at a time, which is the feature.
+- **Fork or vendor the prompt.** Removes the version coupling and buys full control, at the cost of
+  owning clack's render loop and keypress handling forever. Too much surface for what amounts to a
+  cursor-stepping helper.
+- **Depend only on `@clack/core` and drop `@clack/prompts`.** One copy by construction, but macup
+  uses prompts' `select`, `text`, `confirm`, `spinner` and `note` throughout. Reimplementing them to
+  fix a pin is the tail wagging the dog.
+- **A pnpm `overrides` entry forcing one core version.** Deduplicates, but by overriding a
+  constraint the publisher set deliberately, and it hides the coupling in the workspace root instead
+  of stating it. It also silently picks a winner when the versions genuinely differ.
+- **Range instead of exact pin (`~1.2.0`).** Reads as normal, and re-splits the moment a patch
+  ships, reintroducing a bug whose symptom points nowhere near dependency resolution.
+
+## Consequences
+
+- Upgrading `@clack/prompts` is now a two-line change, and forgetting the second line reintroduces a
+  silent-cancel bug. The regression test is what converts that from a field report into a CI
+  failure, so it should not be deleted as redundant.
+- Dependabot or Renovate will offer `@clack/core` bumps that must be refused unless `@clack/prompts`
+  moves first. The pin exists to make that refusal the default.
+- macup is exposed to `AutocompletePrompt` being core-internal API in spirit: it is exported and
+  typed, but the finished prompts are what clack documents. A minor core release may change
+  `filteredOptions`, `selectedValues` or the `'key'` event without calling it a breaking change.
+  `test/regression/picker-returns-values.test.ts` exercises the real prompt over mock streams, so
+  such a change breaks a test rather than a user's terminal.
+- The same reasoning applies to any future package that pins a shared transitive dependency exactly
+  and exposes identity-based sentinels (symbols, private classes, `instanceof` checks). The general
+  lesson is that a dual-package hazard reads as a logic bug, so the cheap guard is asserting the
+  contract across the package boundary, as that test does.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -55,3 +55,4 @@ ADR-NNNN". Do not rewrite the old record. The trail is the point.
 | [0025](0025-release-pr-ci-gate-scope.md) | Release PRs exempt from whole-history CI gates | accepted |
 | [0026](0026-adopt-js-tui-stack.md) | Adopt the playbook's JS TUI utility stack | accepted |
 | [0027](0027-retire-sandcastle-orchestration.md) | Retire the Sandcastle orchestration | accepted |
+| [0028](0028-clack-core-subclassing-and-pin.md) | Subclass @clack/core's AutocompletePrompt, and pin core to prompts' version | accepted |

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
   apps/cli:
     dependencies:
       '@clack/core':
-        specifier: ^1.3.0
-        version: 1.3.0
+        specifier: 1.2.0
+        version: 1.2.0
       '@clack/prompts':
         specifier: ^1.2.0
         version: 1.2.0
@@ -193,10 +193,6 @@ packages:
 
   '@clack/core@1.2.0':
     resolution: {integrity: sha512-qfxof/3T3t9DPU/Rj3OmcFyZInceqj/NVtO9rwIuJqCUgh32gwPjpFQQp/ben07qKlhpwq7GzfWpST4qdJ5Drg==}
-
-  '@clack/core@1.3.0':
-    resolution: {integrity: sha512-xJPHpAmEQUBrXSLx0gF+q5K/IyihXpsHZcha+jB+tyahsKRK3Dxo4D0coZDewHo12NhiuzC3dTtMPbm53GEAAA==}
-    engines: {node: '>= 20.12.0'}
 
   '@clack/prompts@1.2.0':
     resolution: {integrity: sha512-4jmztR9fMqPMjz6H/UZXj0zEmE43ha1euENwkckKKel4XpSfokExPo5AiVStdHSAlHekz4d0CA/r45Ok1E4D3w==}
@@ -1886,20 +1882,11 @@ packages:
   fast-string-truncated-width@1.2.1:
     resolution: {integrity: sha512-Q9acT/+Uu3GwGj+5w/zsGuQjh9O1TyywhIwAxHudtWrgF09nHOPrvTLhQevPbttcxjr/SNN7mJmfOw/B1bXgow==}
 
-  fast-string-truncated-width@3.0.3:
-    resolution: {integrity: sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==}
-
   fast-string-width@1.1.0:
     resolution: {integrity: sha512-O3fwIVIH5gKB38QNbdg+3760ZmGz0SZMgvwJbA1b2TGXceKE6A2cOlfogh1iw8lr049zPyd7YADHy+B7U4W9bQ==}
 
-  fast-string-width@3.0.2:
-    resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
-
   fast-wrap-ansi@0.1.6:
     resolution: {integrity: sha512-HlUwET7a5gqjURj70D5jl7aC3Zmy4weA1SHUfM0JFI0Ptq987NH2TwbBFLoERhfwk+E+eaq4EK3jXoT+R3yp3w==}
-
-  fast-wrap-ansi@0.2.0:
-    resolution: {integrity: sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -3070,11 +3057,6 @@ snapshots:
   '@clack/core@1.2.0':
     dependencies:
       fast-wrap-ansi: 0.1.6
-      sisteransi: 1.0.5
-
-  '@clack/core@1.3.0':
-    dependencies:
-      fast-wrap-ansi: 0.2.0
       sisteransi: 1.0.5
 
   '@clack/prompts@1.2.0':
@@ -4445,23 +4427,13 @@ snapshots:
 
   fast-string-truncated-width@1.2.1: {}
 
-  fast-string-truncated-width@3.0.3: {}
-
   fast-string-width@1.1.0:
     dependencies:
       fast-string-truncated-width: 1.2.1
 
-  fast-string-width@3.0.2:
-    dependencies:
-      fast-string-truncated-width: 3.0.3
-
   fast-wrap-ansi@0.1.6:
     dependencies:
       fast-string-width: 1.1.0
-
-  fast-wrap-ansi@0.2.0:
-    dependencies:
-      fast-string-width: 3.0.2
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:


### PR DESCRIPTION
## What changed and why

Reported from a live run: Add/Remove on `brew:casks` rendered every tracked package as `undefined`, emitted `+undefined` for each pick, and replaced 38 tracked casks with a single YAML `null`. Every run after that died on load, and cancelling the picker threw `TypeError: arr.map is not a function`. Three symptoms, two root causes, and three missing guards.

### The data loss

`pageableAutocompleteMultiselect` cast clack's resolved value to `PickerOption[]` and read `.value` off each entry. `AutocompletePrompt extends Prompt<T['value'] | T['value'][]>` and submit assigns from `selectedValues` — it resolves the selected **values**. Reading `.value` off a string gives `undefined`. The cast was an assertion, not a check, so typecheck had nothing to catch: the compiler was told the answer.

Those undefineds reached `ConfigStore.add`, serialized as `null`, and overwrote the user's list. The schema only objected on the *next* load, once the good data was gone.

### The crash on cancel

Subclassing `AutocompletePrompt` means importing `@clack/core` directly while also using `@clack/prompts`, which pins core to an **exact** version — so `^1.3.0` here resolved a **second copy**. core's cancel sentinel is `Symbol('clack:cancel')`, unique per copy, so `isCancel()` from `@clack/prompts` silently returned `false` for our prompt's cancel and the sentinel flowed on as if it were an answer.

### Fixes

- **`fix(ui)`** — return the resolved values; render picked rows by resolving values back to options. Pin `@clack/core` to the version `@clack/prompts` pins. `pageableSelect` carried the identical cast and is fixed and covered too.
- **`fix(config)`** — validate before writing, so a bad mutation fails with the file on disk intact. Render issues as `brew.casks[0]: expected string, received null` instead of a ZodError JSON dump, and point at `macup restore` when a backup exists.
- **`fix(cli)`** — a throwing picker unwinds to the plugin list instead of killing the session; a `MacupError` prints its message instead of an internal stack trace.

### Why the tests missed it

The seam was drawn directly above the bug. The wizard tests stub `pickTrackedSet` with hand-written strings; the ConfigStore tests feed `add()` hand-written strings. Both sides of the bridge were tested and the bridge — `promptTrackedSetPicker` → `pageableAutocompleteMultiselect` → the cast — had no test at all. Nothing referenced `wizard-runner.ts` or `ui/picker.ts`.

The new regression tests drive the **real** prompt over mock streams, so the values under assertion are the prompt's, not the test's. Each was confirmed to fail against the old code: the picker tests reproduce `expected [ undefined, undefined ]`, and the cancel test reproduces the silent `isCancel` false when the pin is reverted.

### Review round (`9aa961a`)

Two-axis review found the fix was half-applied:

- **The boundary was asymmetric.** `pickTarget` was called bare while only `pickAction` was wrapped — same prompt module, same clack coupling, so the identical crash one screen earlier still escaped. Now guarded.
- **`process.exit()` could truncate a piped stdout** mid-flush, on the one path whose job is getting a message out. Now sets `process.exitCode` and returns.
- **Standards.** `CODING_STANDARDS.md:49` routes user output through `src/ui/` (the new wizard lines used raw `console.error`); `:107` requires error-path tests to assert the `MacupError` subclass *and* the `exitCode`. Both fixed.
- **`recoveryHint` over-promised**, counting every `*.yaml` rather than what `macup restore` actually lists. Now shares `BackupStore`'s own pattern.

### ADR 0028

The PR originally raised the pin as an open question. The review sharpened it, and it's now recorded: the durable decision isn't the pin, it's **subclassing `@clack/core`'s `AutocompletePrompt` while consuming `@clack/prompts`**, which welds macup to prompts' exact core pin permanently. `@clack/prompts` is still a `^` range, so a prompts bump re-splits core until someone re-pins — exactly the trap this hit, and the reason the cancel test asserts through the package boundary.

### Verified

Reproduced the reported failure against the built CLI with the user's real corrupt config, then confirmed `brew list --subtype=casks` recovers once restored. 549 tests pass; lint, typecheck, build, `adr:check` and the de-slop gate are green.

## Checklist

- [x] Title and commits are Conventional Commits (`type(scope): summary`).
- [x] Lint and types pass (`pnpm lint && pnpm typecheck`).
- [x] Tests pass (`pnpm test`), and new behaviour has a test.
- [x] Build passes (`pnpm build`).