### PR TITLE
docs(cli): say `macup restore`, and spell a config path one way

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,8 +152,8 @@ skip:
 Automatic timestamped backups are created before every config mutation (`add`, `remove`, `pin`, `skip`). If no changes occurred, the backup is deleted. Manage backups with:
 
 ```bash
-macup --cleanup    # Delete all backup files (with confirmation)
-macup --restore    # Interactively pick and restore a backup
+macup cleanup      # Delete all backup files (with confirmation)
+macup restore      # Interactively pick and restore a backup
 ```
 
 ## Shell completions

--- a/apps/cli/src/commands/config.ts
+++ b/apps/cli/src/commands/config.ts
@@ -3,7 +3,7 @@ import { readFile } from 'node:fs/promises';
 import { parse } from 'yaml';
 import type { CliDeps, FlagAction, ParsedArgs } from '../cli/types';
 import type { PathResolution } from '../config/paths';
-import { ApplistSchema, SCHEMA_VERSION } from '../config/schema';
+import { ApplistSchema, SCHEMA_VERSION, formatApplistIssueLines } from '../config/schema';
 
 export interface ConfigReport {
   applistPath: string;
@@ -44,9 +44,10 @@ export async function buildConfigReport(paths: PathResolution): Promise<ConfigRe
     const result = ApplistSchema.safeParse(parsed ?? {});
     if (!result.success) {
       report.schemaValid = false;
-      report.schemaError = result.error.issues
-        .map((i) => `${i.path.join('.')}: ${i.message}`)
-        .join('; ');
+      // Shared with the store's load/save errors so a path is spelled the
+      // same everywhere: `brew.casks[0]`, not `brew.casks.0` here and
+      // `brew.casks[0]` there for the identical problem.
+      report.schemaError = formatApplistIssueLines(result.error).join('; ');
     } else if (result.data.version > SCHEMA_VERSION) {
       // Mirror the store's load-time rejection: a newer-than-supported
       // version is not something this build can safely read, so `--config`

--- a/apps/cli/src/commands/doctor/checks/config.ts
+++ b/apps/cli/src/commands/doctor/checks/config.ts
@@ -93,7 +93,7 @@ export async function check(deps: CheckDeps): Promise<Section> {
       level: 'error',
       label: 'applist.yaml',
       detail: `${report.applistPath} — ${report.schemaError ?? 'failed validation'}`,
-      hint: 'fix the schema error, or restore a backup: macup --restore',
+      hint: 'fix the schema error, or restore a backup: macup restore',
     });
   }
 

--- a/apps/cli/src/config/schema.ts
+++ b/apps/cli/src/config/schema.ts
@@ -65,10 +65,20 @@ function formatPath(path: ReadonlyArray<PropertyKey>): string {
 }
 
 /**
- * One human-readable line per problem. `ZodError.message` is a JSON dump
- * of every issue — accurate, but it buries the one thing the user needs
- * (which line of their YAML is wrong) in ~10 lines of machine output.
+ * One human-readable line per problem, for callers that pick their own
+ * separator: the store stacks them on newlines, `--config` inlines them
+ * with `; ` into a one-line summary. Both must SPELL a path the same way,
+ * which is the whole reason this isn't two `.map()`s in two files.
+ */
+export function formatApplistIssueLines(error: z.ZodError): string[] {
+  return error.issues.map((issue) => `${formatPath(issue.path)}: ${issue.message}`);
+}
+
+/**
+ * The same problems as a block. `ZodError.message` is a JSON dump of every
+ * issue — accurate, but it buries the one thing the user needs (which line
+ * of their YAML is wrong) in ~10 lines of machine output.
  */
 export function formatApplistIssues(error: z.ZodError): string {
-  return error.issues.map((issue) => `${formatPath(issue.path)}: ${issue.message}`).join('\n');
+  return formatApplistIssueLines(error).join('\n');
 }

--- a/apps/cli/test/regression/config-errors-are-actionable.test.ts
+++ b/apps/cli/test/regression/config-errors-are-actionable.test.ts
@@ -11,6 +11,8 @@ import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { buildConfigReport } from '../../src/commands/config';
+import type { PathResolution } from '../../src/config/paths';
 import { ConfigStore } from '../../src/config/store';
 import { ErrInvalidConfig } from '../../src/errors';
 
@@ -31,6 +33,10 @@ beforeEach(async () => {
 afterEach(async () => {
   await rm(workDir, { recursive: true, force: true });
 });
+
+function configPaths(): PathResolution {
+  return { applistPath, configDir: workDir, backupDir, source: 'home-macup' };
+}
 
 async function loadCorrupt(): Promise<Error> {
   await writeFile(applistPath, CORRUPT, 'utf8');
@@ -59,6 +65,34 @@ describe('regression: an invalid config names the offending key', () => {
     // The old message was raw ZodError JSON — these are its fingerprints.
     expect(err.message).not.toContain('"code"');
     expect(err.message).not.toContain('"invalid_type"');
+  });
+});
+
+// `--config` / `doctor` render the same zod issues as the store does, and
+// used to hand-roll their own `path.join('.')`, so one broken file was
+// `brew.casks[0]` from `brew list` and `brew.casks.0` from `doctor`. Both
+// now share formatApplistIssueLines; this pins them together.
+describe('regression: every surface spells a config path the same way', () => {
+  it('reports the store path style from buildConfigReport too', async () => {
+    await writeFile(applistPath, CORRUPT, 'utf8');
+
+    const report = await buildConfigReport(configPaths());
+
+    expect(report.schemaValid).toBe(false);
+    expect(report.schemaError).toContain('brew.casks[0]');
+    expect(report.schemaError).not.toContain('brew.casks.0');
+  });
+
+  it('matches the message the store raises for the same file', async () => {
+    // loadCorrupt() writes the file, so it has to run before the report.
+    const err = await loadCorrupt();
+    const report = await buildConfigReport(configPaths());
+
+    // Same file, same problem — so the same words, whichever door you came
+    // through.
+    const path = 'brew.casks[0]: Invalid input: expected string, received null';
+    expect(report.schemaError).toContain(path);
+    expect(err.message).toContain(path);
   });
 });
 

--- a/apps/docs/content/docs/guides/configuration.mdx
+++ b/apps/docs/content/docs/guides/configuration.mdx
@@ -44,4 +44,4 @@ and its type.
 
 A timestamped backup is written before every config mutation (`add`, `remove`,
 `pin`, `skip`). If nothing changed, the backup is removed. Manage them with
-`macup --cleanup` and `macup --restore`.
+`macup cleanup` and `macup restore`.

--- a/apps/docs/content/docs/guides/safe-updates.mdx
+++ b/apps/docs/content/docs/guides/safe-updates.mdx
@@ -92,12 +92,12 @@ Details that keep backups honest:
 
 ## Restore from a backup
 
-`macup --restore` lists your backups newest-first, lets you pick one, and
+`macup restore` lists your backups newest-first, lets you pick one, and
 confirms before overwriting `applist.yaml`.
 
 ```bash
-macup --restore
-# macup restore is rewritten to this form
+macup restore
+# rewritten to macup --restore at argv parse time; both forms work
 ```
 
 The picker labels each entry as `<timestamp>  (<operation>)`. The confirm

--- a/apps/docs/content/docs/recipes/back-up-before-a-risky-upgrade.mdx
+++ b/apps/docs/content/docs/recipes/back-up-before-a-risky-upgrade.mdx
@@ -50,7 +50,7 @@ This upgrades the brew packages you track that are outdated. To extend it to eve
 A bad `pin`, `skip`, or `remove` is recoverable. macup copied `applist.yaml` to a timestamped backup before the edit. List the backups, pick one, and confirm.
 
 ```bash
-macup --restore
+macup restore
 ```
 
 The picker labels each entry `<timestamp>  (<operation>)`, newest first. The confirm prompt defaults to no, so a successful restore is deliberate. macup prints `Restored from <filename>.`
@@ -69,7 +69,7 @@ Cleanup is all-or-nothing and asks for one confirmation before deleting every ba
 
 <Callout type="warn">
 
-`--restore` overwrites `applist.yaml` in place and does not back up the file it replaces first. The restore itself is not reversible through the backup system. Make sure you picked the right backup before confirming.
+`macup restore` overwrites `applist.yaml` in place and does not back up the file it replaces first. The restore itself is not reversible through the backup system. Make sure you picked the right backup before confirming.
 
 </Callout>
 

--- a/apps/docs/content/docs/troubleshooting/faq.mdx
+++ b/apps/docs/content/docs/troubleshooting/faq.mdx
@@ -68,7 +68,7 @@ See [How macup works](/docs/concepts/how-it-works) for the full model.
 
 There is no automatic rollback of packages. To go back, reinstall the prior version through the backend (for example `brew install <formula>@<version>`).
 
-Backups protect your `applist.yaml`, not your installed packages. Every config mutation writes a timestamped copy you can restore with `macup --restore`. See [Safe updates](/docs/guides/safe-updates) for what is and is not reversible.
+Backups protect your `applist.yaml`, not your installed packages. Every config mutation writes a timestamped copy you can restore with `macup restore`. See [Safe updates](/docs/guides/safe-updates) for what is and is not reversible.
 
 </Accordion>
 

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -6,7 +6,7 @@ One directory per shipped feature, each holding a single `requirements.md` of te
 |---|---|
 | [Unified outdated view](unified-outdated/requirements.md) | One parallel, failure-isolated pane answering "what's outdated across my whole machine?", with `--json`. |
 | [Interactive wizard](interactive-wizard/requirements.md) | Bare `macup` on a TTY: category picker, capability-gated actions, paged package pickers, dispatch into the real subcommands. |
-| [Applist config and backups](applist-config/requirements.md) | Hierarchical applist.yaml with XDG path resolution, comment-preserving round trips, auto-migration, atomic saves, timestamped backups, `--restore` and `--cleanup`. |
+| [Applist config and backups](applist-config/requirements.md) | Hierarchical applist.yaml with XDG path resolution, comment-preserving round trips, auto-migration, atomic saves, timestamped backups, `macup restore` and `macup cleanup`. |
 | [Selective updates](selective-updates/requirements.md) | Per-package pins and skip lists classified at update time, so one held-back package never blocks the rest. |
 | [Plugin system](plugin-system/requirements.md) | Closed builtin registry, OS and PATH availability filtering, typed `ErrPluginUnavailable`, and the composite `all` with per-plugin error isolation. |
 | [Per-plugin package commands](package-commands/requirements.md) | Manifest-generated list, install, update, add, and remove with tracked-by-default scoping, `--all`, `--only-outdated`, and brew `--cask`/`--formula`. |

--- a/docs/features/applist-config/requirements.md
+++ b/docs/features/applist-config/requirements.md
@@ -26,7 +26,7 @@
 
 ### Restore and cleanup
 
-12. `macup --restore` (or `macup restore`) lists backups newest first, asks for a target and a confirmation (default No), then copies the chosen backup over the live applist; with no backups it prints `No backups found` and exits 0.
+12. `macup restore` (or `macup --restore`) lists backups newest first, asks for a target and a confirmation (default No), then copies the chosen backup over the live applist; with no backups it prints `No backups found` and exits 0.
 13. `macup --cleanup` (or `macup cleanup`) lists every `applist_*.yaml` backup, requires confirmation (default No), deletes them all, reports the count, and removes the backup dir if it is left empty.
 
 ## Source of truth

--- a/docs/features/dry-run/requirements.md
+++ b/docs/features/dry-run/requirements.md
@@ -19,4 +19,4 @@
 
 ## Out of scope
 
-`add`, `remove`, `pin`, and `skip` have no dry-run flag; they are config-only edits already guarded by timestamped backups and `--restore`.
+`add`, `remove`, `pin`, and `skip` have no dry-run flag; they are config-only edits already guarded by timestamped backups and `macup restore`.


### PR DESCRIPTION
## What changed and why

Follow-up to #65, which surfaced two places where macup said the same thing two ways.

### `macup restore` is the recommended form

The doctor hint said `macup --restore` while the invalid-config error added in #65 said `macup restore`, and the docs were split. `macup restore` wins.

The flag stays a working alias — `FLAG_COMMAND_ALIASES` rewrites the bare word to `--restore` at argv parse time — so **this changes what we tell people to type, not what runs**. README already led bare-first at line 59 (`macup restore  # or: macup --restore`); the backups block and the docs site now match it.

Left deliberately:

- `reference/global-flags.mdx` — generated by `apps/docs/scripts/generate-reference.ts`, and it documents the flag with the bare form already beside it in the "Also as" column.
- `docs/PRD.md`, `docs/adr/0006`, `docs/audit/`, `docs/superpowers/` — records of what was decided at the time. Rewriting them would be rewriting history.
- The three remaining `macup --restore` mentions, which each document the alias with `macup restore` leading.

`--cleanup` came along in the two spots where it sits directly beside restore in the same block, since leaving one bare and one flagged mid-block reads as a typo.

### One spelling for a config path

`--config` and `doctor` hand-rolled their own zod-issue rendering with `path.join('.')`, so a single broken file read:

| Surface | Before | After |
| --- | --- | --- |
| `macup brew list` | `brew.casks[0]` | `brew.casks[0]` |
| `macup doctor` | `brew.casks.0` | `brew.casks[0]` |
| `macup config` | `brew.casks.0` | `brew.casks[0]` |

A difference with no meaning behind it, which is the worst kind to hand someone mid-debug — and #65 made it worse by adding the second formatter. They now share `formatApplistIssueLines` with the store. Callers keep their own separator (`; ` inline for the one-line summary, newlines for a block) because that part genuinely differs; the path rendering, which must not, is shared.

### Verified

All three surfaces against the built CLI on the same corrupt file:

```
doctor:     ✖ applist.yaml … — brew.casks[0]: Invalid input: expected string, received null
              ↳ fix the schema error, or restore a backup: macup restore
config:     schema:      INVALID — brew.casks[0]: Invalid input: expected string, received null
brew list:  error: Invalid configuration at … : brew.casks[0]: Invalid input: expected string, received null
```

The reconcile is the whole point, so a test pins it: the same corrupt file must produce the same words through `buildConfigReport` and through the store. Confirmed it fails against the old formatter (`Expected: "brew.casks[0]" / Received: "brew.casks.0: …"`).

551 tests pass; lint, typecheck, build, `adr:check` and the de-slop gate are green.

## Checklist

- [x] Title and commits are Conventional Commits (`type(scope): summary`).
- [x] Lint and types pass (`pnpm lint && pnpm typecheck`).
- [x] Tests pass (`pnpm test`), and new behaviour has a test.
- [x] Build passes (`pnpm build`).