### PR TITLE
feat(cli)!: make --completions a command, and fix the shell-value no-op

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,12 +170,12 @@ For zsh, this also clears cached `.zcompdump` files so the new completions load 
 
 ### Manual install (dotfiles / scripting)
 
-`--completions` emits to stdout, useful when you want full control over the path or are writing dotfiles:
+`macup completions` emits to stdout, useful when you want full control over the path or are writing dotfiles:
 
 ```bash
-macup --completions=zsh  > ~/.local/share/zsh/site-functions/_macup
-macup --completions=bash > ~/.local/share/bash-completion/completions/macup
-macup --completions=fish > ~/.config/fish/completions/macup.fish
+macup completions zsh  > ~/.local/share/zsh/site-functions/_macup
+macup completions bash > ~/.local/share/bash-completion/completions/macup
+macup completions fish > ~/.config/fish/completions/macup.fish
 ```
 
 Both forms accept an explicit shell (`zsh`/`bash`/`fish`) or auto-detect from `$SHELL` when the value is omitted.

--- a/apps/cli/src/cli.ts
+++ b/apps/cli/src/cli.ts
@@ -7,16 +7,16 @@
 //   4. intercept --version / --help (citty's defaults are unstyled).
 //      Done before the registry availability probe so `macup --help`
 //      on a fresh machine doesn't print missing-binary warnings.
-//   5. register flag actions + per-plugin subcommands + outdated subcommand
-//   6. defineCommand({ subCommands, args (merged from flag actions), run })
+//   5. adapt the action commands + per-plugin subcommands into one tree
+//   6. defineCommand({ subCommands, run })
 //   7. runMain
 //
 // Real work lives elsewhere:
 //   - src/cli/argv.ts          — argv preprocessing
 //   - src/cli/bootstrap.ts     — runtime wiring (exec/bar/registry/store/log)
 //   - src/cli/help.ts          — printVersionSplash, showCustomHelp
-//   - src/cli/types.ts         — CliDeps + FlagAction shapes
-//   - src/commands/<name>.ts   — each FlagAction + per-plugin subcommand factory
+//   - src/cli/types.ts         — CliDeps + ActionCommand shapes
+//   - src/commands/<name>.ts   — each ActionCommand + per-plugin subcommand factory
 //   - src/wizard-runner.ts     — interactive default action
 
 import type { ArgsDef, CommandDef } from 'citty';
@@ -24,7 +24,7 @@ import { defineCommand, runMain } from 'citty';
 import { extractVerbosityFlags, findUnknownTopLevelFlags, rewriteFlagAliases } from './cli/argv';
 import { bootstrap } from './cli/bootstrap';
 import { printVersionSplash, showCustomHelp } from './cli/help';
-import type { FlagAction } from './cli/types';
+import type { ActionCommand } from './cli/types';
 import { buildCheckCommand } from './commands/check';
 import { CleanupAction } from './commands/cleanup';
 import { CompletionsAction } from './commands/completions';
@@ -37,6 +37,7 @@ import { LogoAction } from './commands/logo';
 import { buildOutdatedCommand } from './commands/outdated';
 import { PluginsAction } from './commands/plugins';
 import { RestoreAction } from './commands/restore';
+import { SUPPORTED_SHELLS } from './commands/shell';
 import { UndoAction } from './commands/undo';
 import { MacupError } from './errors';
 import { BUILTIN_PLUGINS } from './plugins/registry';
@@ -89,9 +90,10 @@ if (
 // (`--json`, `--dry-run`, `--verbose`); it isn't the command itself. They
 // were flags because the tool grew out of a bash script that only had
 // flags (ADR 0029).
-const NOUN_ACTIONS: readonly FlagAction[] = [
+const NOUN_ACTIONS: readonly ActionCommand[] = [
   new LogoAction(),
   new PluginsAction(),
+  new CompletionsAction(),
   new InstallCompletionsAction(),
   new ConfigAction(),
   new CleanupAction(),
@@ -100,25 +102,42 @@ const NOUN_ACTIONS: readonly FlagAction[] = [
   new DoctorAction(),
 ];
 
-// `--completions[=<shell>]` stays a flag: it takes a value, it's machine
-// plumbing that the generated completion scripts reference by name, and
-// `install-completions` is the noun a human reaches for.
-const flagActions: readonly FlagAction[] = [new CompletionsAction()];
-
 /**
- * Adapts a FlagAction into the citty subcommand it should always have
- * been. Invoking the subcommand IS the trigger, so its boolean flag is
- * dropped from the arg schema and synthesised for run() — the actions
- * keep their existing `matches`/`run` contract, and the wizard and tests
- * that drive them directly are untouched.
+ * Adapts an ActionCommand into the citty subcommand it should always have
+ * been. Invoking the subcommand IS the trigger, so the trigger arg is
+ * dropped from the schema and synthesised for run() — the actions keep
+ * their existing `run` contract, and everything driving them directly is
+ * untouched.
+ *
+ * Two trigger shapes, and conflating them is a silent no-op rather than a
+ * crash, so it's worth being explicit. A boolean trigger (`--restore`)
+ * carries no information beyond "this one", and becomes `true`. A string
+ * trigger (`--completions=zsh`) carries the shell, so it becomes a
+ * positional `[shell]` — `''` when omitted, which is what these actions
+ * already read as "auto-detect from $SHELL".
  */
-function subCommandFromAction(action: FlagAction): CommandDef {
+function subCommandFromAction(action: ActionCommand): CommandDef {
+  const trigger = action.args[action.name] as { type?: string } | undefined;
+  const takesValue = trigger?.type === 'string';
   const { [action.name]: _trigger, ...modifiers } = action.args;
+
+  const args: ArgsDef = takesValue
+    ? {
+        ...(modifiers as ArgsDef),
+        shell: {
+          type: 'positional',
+          required: false,
+          description: `Shell to target: ${SUPPORTED_SHELLS.join(' | ')}. Omit to auto-detect from $SHELL.`,
+        },
+      }
+    : (modifiers as ArgsDef);
+
   return defineCommand({
     meta: { name: action.name, description: action.description },
-    args: modifiers as ArgsDef,
-    async run({ args }) {
-      await action.run({ ...args, [action.name]: true }, deps);
+    args,
+    async run({ args: parsed }) {
+      const triggerValue = takesValue ? ((parsed.shell as string | undefined) ?? '') : true;
+      await action.run({ ...parsed, [action.name]: triggerValue }, deps);
     },
   });
 }
@@ -205,27 +224,12 @@ for (const plugin of BUILTIN_PLUGINS) {
   }
 }
 
-// Merge args contributions from every FlagAction — this is what citty's
-// arg parser sees on the main command. Each action's `matches()` then
-// inspects the parsed bag to decide whether it owns the run. Reject
-// duplicate flag names at startup rather than letting the second action
-// silently shadow the first.
-const flagActionArgs: ArgsDef = {};
-for (const action of flagActions) {
-  for (const [name, def] of Object.entries(action.args)) {
-    if (name in flagActionArgs) {
-      throw new Error(
-        `FlagAction "${action.name}" registers duplicate flag --${name} (already claimed)`,
-      );
-    }
-    flagActionArgs[name] = def;
-  }
-}
-
 // Known top-level flags, for rejecting unknown ones (A-1). citty is permissive
 // about unrecognised --flags on the root command, so we detect them ourselves
 // before falling through to the wizard. --help/--version are intercepted above;
-// verbosity flags are stripped from argv before citty.
+// verbosity flags are stripped from argv before citty. Every action now owns a
+// subcommand (ADR 0029), so this list is the whole top-level flag surface —
+// nothing is merged in from the actions any more.
 const KNOWN_TOP_LEVEL_FLAGS = new Set<string>([
   '--help',
   '-h',
@@ -236,13 +240,6 @@ const KNOWN_TOP_LEVEL_FLAGS = new Set<string>([
   '--debug',
   '-D',
 ]);
-for (const [name, def] of Object.entries(flagActionArgs)) {
-  KNOWN_TOP_LEVEL_FLAGS.add(`--${name}`);
-  const alias = (def as { alias?: string | string[] }).alias;
-  if (alias) {
-    for (const a of Array.isArray(alias) ? alias : [alias]) KNOWN_TOP_LEVEL_FLAGS.add(`-${a}`);
-  }
-}
 
 const main = defineCommand({
   meta: {
@@ -252,30 +249,12 @@ const main = defineCommand({
       'macup — macOS package update tool with plugin architecture, pins, skip, interactive wizard, and shell completions.',
   },
   subCommands: topLevelSubCommands,
-  args: flagActionArgs,
-  async run({ args, rawArgs }) {
+  async run({ rawArgs }) {
     // citty calls the parent run() even after a subcommand dispatches.
     // If the first raw arg matches a known subcommand, the subcommand
     // already handled it — bail to avoid double output.
     const first = rawArgs[0];
     if (first && first in topLevelSubCommands) return;
-
-    const argsBag = args as Record<string, unknown>;
-    for (const action of flagActions) {
-      if (action.matches(argsBag)) {
-        try {
-          await action.run(argsBag, deps);
-        } catch (err) {
-          if (err instanceof MacupError) {
-            console.error(`error: ${err.message}`);
-            process.exitCode = err.exitCode;
-            return;
-          }
-          throw err;
-        }
-        return;
-      }
-    }
 
     // No flag matched: reject unknown top-level flags (A-1) before falling
     // through to the wizard, so `macup --bogus` errors instead of exiting 0.

--- a/apps/cli/src/cli/types.ts
+++ b/apps/cli/src/cli/types.ts
@@ -3,21 +3,17 @@
 // `CliDeps` is the bag of everything wired up at startup (exec runner,
 // status bar, plugin registry, lazy config store, log, env-resolved
 // paths, color/verbose/debug flags). It's threaded through every
-// FlagAction.run(); each action grabs what it needs and ignores the
-// rest. A single deps shape keeps the dispatch loop trivial — no
-// per-action wiring in cli.ts.
+// ActionCommand.run(); each action grabs what it needs and ignores the
+// rest. A single deps shape keeps the wiring trivial — no per-action
+// wiring in cli.ts.
 //
-// `FlagAction` covers the top-level `--cleanup` / `--restore` / `--logo`
-// / `--plugins` / `--config` / `--completions` / `--install-completions`
-// surface. These are flag-triggered actions on the main command (not
-// citty subcommands), so each contributes its own `args` schema and
-// declares a `matches()` predicate. cli.ts iterates the registered
-// actions in order; the first one whose matches() returns true takes
-// over the run() and short-circuits the wizard fallback.
-//
-// Real citty subcommands (`brew`, `npm`, `outdated`, etc.) keep their
-// own dispatch via `subCommands` on the main definition; FlagAction is
-// only for the flag-on-main surface.
+// `ActionCommand` covers the stand-alone commands: `macup cleanup`,
+// `restore`, `logo`, `plugins`, `config`, `completions`,
+// `install-completions`, `undo`, `doctor`. Each carries its own `args`
+// schema and a `run()`; cli.ts adapts them into citty subcommands
+// (ADR 0029). They were `FlagAction`s — flag-triggered actions on the
+// main command with a `matches()` predicate — back when they were
+// spelled `--restore`.
 
 import type { ArgsDef } from 'citty';
 import type { PathResolution } from '../config/paths';
@@ -47,13 +43,16 @@ export interface CliDeps {
   readonly abort: () => void;
 }
 
-export interface FlagAction {
+export interface ActionCommand {
+  /** The command word: `macup <name>`. Also the key of the trigger arg in `args`. */
   readonly name: string;
   readonly description: string;
-  /** Args this action contributes to the main command. Merged at registration time. */
+  /**
+   * The action's own arg schema. The entry keyed by `name` is the trigger:
+   * `boolean` for a plain command, `string` when the command takes a value
+   * (the shell, for the completion commands). cli.ts reads that type to
+   * decide the subcommand's shape, so keep the two in step.
+   */
   readonly args: ArgsDef;
-  /** True iff the parsed args bag indicates this action was requested. */
-  matches(args: ParsedArgs): boolean;
-  /** Execute. Caller has already verified matches(args). */
   run(args: ParsedArgs, deps: CliDeps): Promise<void>;
 }

--- a/apps/cli/src/commands/cleanup.ts
+++ b/apps/cli/src/commands/cleanup.ts
@@ -1,5 +1,5 @@
 import { confirm, isCancel } from '@clack/prompts';
-import type { CliDeps, FlagAction, ParsedArgs } from '../cli/types';
+import type { ActionCommand, CliDeps, ParsedArgs } from '../cli/types';
 import { BackupStore } from '../config/backup';
 
 export interface CleanupDeps {
@@ -47,7 +47,7 @@ export async function runCleanupAction(_args: ParsedArgs, deps: CliDeps): Promis
   });
 }
 
-export class CleanupAction implements FlagAction {
+export class CleanupAction implements ActionCommand {
   readonly name = 'cleanup';
   readonly description = 'Interactively delete all backup files.';
   readonly args = {
@@ -56,10 +56,6 @@ export class CleanupAction implements FlagAction {
       description: 'Interactively delete all backup files.',
     },
   };
-
-  matches(args: ParsedArgs): boolean {
-    return args.cleanup === true;
-  }
 
   run = runCleanupAction;
 }

--- a/apps/cli/src/commands/completions.ts
+++ b/apps/cli/src/commands/completions.ts
@@ -6,7 +6,7 @@
 // resolution, but writes to stdout instead of the XDG completions path.
 // Useful for `eval "$(macup --completions)"` setups.
 
-import type { CliDeps, FlagAction, ParsedArgs } from '../cli/types';
+import type { ActionCommand, CliDeps, ParsedArgs } from '../cli/types';
 import { generateBashCompletions } from '../completions/bash';
 import { generateFishCompletions } from '../completions/fish';
 import { generateZshCompletions } from '../completions/zsh';
@@ -45,7 +45,7 @@ function resolveShell(value: string, env: NodeJS.ProcessEnv): Shell | undefined 
   return undefined;
 }
 
-export class CompletionsAction implements FlagAction {
+export class CompletionsAction implements ActionCommand {
   readonly name = 'completions';
   readonly description =
     `Emit shell completions for ${SUPPORTED_SHELLS.join('|')} (omit value to auto-detect from $SHELL).`;
@@ -56,10 +56,6 @@ export class CompletionsAction implements FlagAction {
       description: `Emit shell completions for ${SUPPORTED_SHELLS.join('|')} (omit value to auto-detect from $SHELL).`,
     },
   };
-
-  matches(args: ParsedArgs): boolean {
-    return typeof args.completions === 'string';
-  }
 
   run = runCompletions;
 }

--- a/apps/cli/src/commands/config.ts
+++ b/apps/cli/src/commands/config.ts
@@ -1,7 +1,7 @@
 import { existsSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
 import { parse } from 'yaml';
-import type { CliDeps, FlagAction, ParsedArgs } from '../cli/types';
+import type { ActionCommand, CliDeps, ParsedArgs } from '../cli/types';
 import type { PathResolution } from '../config/paths';
 import { ApplistSchema, SCHEMA_VERSION, formatApplistIssueLines } from '../config/schema';
 
@@ -104,7 +104,7 @@ export async function runConfig(_args: ParsedArgs, deps: CliDeps): Promise<void>
   console.log(formatConfigReport(report));
 }
 
-export class ConfigAction implements FlagAction {
+export class ConfigAction implements ActionCommand {
   readonly name = 'config';
   readonly description =
     'Show config location, schema status, pin/skip counts, backup dir, and migration hints.';
@@ -115,10 +115,6 @@ export class ConfigAction implements FlagAction {
         'Show config location, schema status, pin/skip counts, backup dir, and migration hints.',
     },
   };
-
-  matches(args: ParsedArgs): boolean {
-    return args.config === true;
-  }
 
   run = runConfig;
 }

--- a/apps/cli/src/commands/doctor.ts
+++ b/apps/cli/src/commands/doctor.ts
@@ -7,7 +7,7 @@
 // any error — warnings never fail the exit.
 
 import { release } from 'node:os';
-import type { CliDeps, FlagAction, ParsedArgs } from '../cli/types';
+import type { ActionCommand, CliDeps, ParsedArgs } from '../cli/types';
 import { BUILTIN_PLUGINS } from '../plugins/registry';
 import { getVersion } from '../version';
 import { check as checkConfig } from './doctor/checks/config';
@@ -70,7 +70,7 @@ export async function runDoctor(args: ParsedArgs, deps: CliDeps): Promise<void> 
   process.exitCode = exitCodeFor(report);
 }
 
-export class DoctorAction implements FlagAction {
+export class DoctorAction implements ActionCommand {
   readonly name = 'doctor';
   readonly description =
     'Run a self-diagnostic report: environment, config, plugin probes, data integrity, shell integration.';
@@ -81,10 +81,6 @@ export class DoctorAction implements FlagAction {
         'Run a self-diagnostic report: environment, config, plugin probes, data integrity, shell integration.',
     },
   };
-
-  matches(args: ParsedArgs): boolean {
-    return args.doctor === true;
-  }
 
   // `--json` is deliberately NOT a registered root arg. Registering it
   // would shadow subcommand `--json` (e.g. `macup outdated --json`) and

--- a/apps/cli/src/commands/install-completions.ts
+++ b/apps/cli/src/commands/install-completions.ts
@@ -1,7 +1,7 @@
 import { existsSync } from 'node:fs';
 import { mkdir, readdir, unlink, writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
-import type { CliDeps, FlagAction, ParsedArgs } from '../cli/types';
+import type { ActionCommand, CliDeps, ParsedArgs } from '../cli/types';
 import { generateBashCompletions } from '../completions/bash';
 import { generateFishCompletions } from '../completions/fish';
 import { generateZshCompletions } from '../completions/zsh';
@@ -173,7 +173,7 @@ function resolveShellArg(value: string, env: NodeJS.ProcessEnv): Shell | undefin
   return undefined;
 }
 
-export class InstallCompletionsAction implements FlagAction {
+export class InstallCompletionsAction implements ActionCommand {
   readonly name = 'install-completions';
   readonly description =
     `Generate and write shell completions to the standard XDG path for ${SUPPORTED_SHELLS.join('|')} (omit value to auto-detect).`;
@@ -184,10 +184,6 @@ export class InstallCompletionsAction implements FlagAction {
       description: `Generate and write shell completions to the standard XDG path for ${SUPPORTED_SHELLS.join('|')} (omit value to auto-detect).`,
     },
   };
-
-  matches(args: ParsedArgs): boolean {
-    return typeof args['install-completions'] === 'string';
-  }
 
   run = runInstallCompletions;
 }

--- a/apps/cli/src/commands/logo.ts
+++ b/apps/cli/src/commands/logo.ts
@@ -5,7 +5,7 @@
 // error and sets exit code 1 — citty's args parser already accepts the
 // flag at the type level, but it doesn't validate the numeric range.
 
-import type { CliDeps, FlagAction, ParsedArgs } from '../cli/types';
+import type { ActionCommand, CliDeps, ParsedArgs } from '../cli/types';
 import { renderAppleLogo } from '../ui/logo';
 
 export async function runLogo(args: ParsedArgs, deps: CliDeps): Promise<void> {
@@ -22,7 +22,7 @@ export async function runLogo(args: ParsedArgs, deps: CliDeps): Promise<void> {
   console.log(renderAppleLogo({ color: deps.color, scale }));
 }
 
-export class LogoAction implements FlagAction {
+export class LogoAction implements ActionCommand {
   readonly name = 'logo';
   readonly description = 'Print the Apple logo (optional scale: 0.25, 0.5, 0.75, or 1).';
   readonly args = {
@@ -32,10 +32,6 @@ export class LogoAction implements FlagAction {
       description: 'Print the Apple logo (optional scale: 0.25, 0.5, 0.75, or 1).',
     },
   };
-
-  matches(args: ParsedArgs): boolean {
-    return typeof args.logo === 'string';
-  }
 
   run = runLogo;
 }

--- a/apps/cli/src/commands/plugins.ts
+++ b/apps/cli/src/commands/plugins.ts
@@ -1,4 +1,4 @@
-import type { CliDeps, FlagAction, ParsedArgs } from '../cli/types';
+import type { ActionCommand, CliDeps, ParsedArgs } from '../cli/types';
 import { BUILTIN_PLUGINS, isOnPath } from '../plugins/registry';
 import type { Plugin, PluginCapabilities } from '../plugins/types';
 
@@ -139,7 +139,7 @@ export async function runPlugins(_args: ParsedArgs, deps: CliDeps): Promise<void
   console.log(formatPluginsReport(report, { color: deps.color }));
 }
 
-export class PluginsAction implements FlagAction {
+export class PluginsAction implements ActionCommand {
   readonly name = 'plugins';
   readonly description = 'List built-in plugins and whether each is available on this machine.';
   readonly args = {
@@ -148,10 +148,6 @@ export class PluginsAction implements FlagAction {
       description: 'List built-in plugins and whether each is available on this machine.',
     },
   };
-
-  matches(args: ParsedArgs): boolean {
-    return args.plugins === true;
-  }
 
   run = runPlugins;
 }

--- a/apps/cli/src/commands/restore.ts
+++ b/apps/cli/src/commands/restore.ts
@@ -1,5 +1,5 @@
 import { confirm, isCancel, outro, select } from '@clack/prompts';
-import type { CliDeps, FlagAction, ParsedArgs } from '../cli/types';
+import type { ActionCommand, CliDeps, ParsedArgs } from '../cli/types';
 import { type BackupEntry, BackupStore } from '../config/backup';
 
 export interface RestoreDeps {
@@ -61,7 +61,7 @@ export async function runRestoreAction(_args: ParsedArgs, deps: CliDeps): Promis
   outro('Done.');
 }
 
-export class RestoreAction implements FlagAction {
+export class RestoreAction implements ActionCommand {
   readonly name = 'restore';
   readonly description = 'Interactively restore the applist from a backup.';
   readonly args = {
@@ -70,10 +70,6 @@ export class RestoreAction implements FlagAction {
       description: 'Interactively restore the applist from a backup.',
     },
   };
-
-  matches(args: ParsedArgs): boolean {
-    return args.restore === true;
-  }
 
   run = runRestoreAction;
 }

--- a/apps/cli/src/commands/undo.ts
+++ b/apps/cli/src/commands/undo.ts
@@ -11,7 +11,7 @@
 
 import { readFile } from 'node:fs/promises';
 import { confirm, isCancel, outro } from '@clack/prompts';
-import type { CliDeps, FlagAction, ParsedArgs } from '../cli/types';
+import type { ActionCommand, CliDeps, ParsedArgs } from '../cli/types';
 import { type BackupEntry, BackupStore } from '../config/backup';
 import { computeLineDiff, formatDiff, hasDiff } from '../ui/diff';
 
@@ -90,7 +90,7 @@ export async function runUndoAction(_args: ParsedArgs, deps: CliDeps): Promise<v
   outro('Done.');
 }
 
-export class UndoAction implements FlagAction {
+export class UndoAction implements ActionCommand {
   readonly name = 'undo';
   readonly description = 'Revert the applist to the most recent backup (with a diff preview).';
   readonly args = {
@@ -99,10 +99,6 @@ export class UndoAction implements FlagAction {
       description: 'Revert the applist to the most recent backup (with a diff preview).',
     },
   };
-
-  matches(args: ParsedArgs): boolean {
-    return args.undo === true;
-  }
 
   run = runUndoAction;
 }

--- a/apps/cli/src/completions/bash.ts
+++ b/apps/cli/src/completions/bash.ts
@@ -6,7 +6,7 @@ export function generateBashCompletions(plugins: readonly Plugin[]): string {
   // restore` is a noun, not a flag (ADR 0029). Only the true modifiers
   // are left on the flag list.
   const ids = [...plugins.map((p) => p.manifest.id), ...TOP_LEVEL_COMMANDS.map((c) => c.name)];
-  const globalFlags = '--help --version --verbose --debug --completions';
+  const globalFlags = '--help --version --verbose --debug';
 
   const pluginCases = plugins
     .map(

--- a/apps/cli/src/completions/shared.ts
+++ b/apps/cli/src/completions/shared.ts
@@ -18,10 +18,19 @@ export const TOP_LEVEL_COMMANDS: ReadonlyArray<{ name: string; description: stri
   { name: 'cleanup', description: 'Delete all config backup files' },
   { name: 'restore', description: 'Restore the applist from a backup' },
   { name: 'undo', description: 'Revert to the most recent backup' },
+  { name: 'completions', description: 'Emit shell completions to stdout' },
   { name: 'install-completions', description: 'Install shell completions' },
   { name: 'version', description: 'Show version with logo' },
   { name: 'logo', description: 'Print the Apple logo' },
 ];
+
+/**
+ * Commands whose one positional is a shell name. `--completions=<shell>`
+ * carried its own value spec, so completion offered the shells for free;
+ * as commands they need this to keep doing it. `init` never offered them
+ * and now can.
+ */
+export const SHELL_ARG_COMMANDS: readonly string[] = ['completions', 'install-completions', 'init'];
 
 export function commandsFor(plugin: Plugin): string[] {
   const cmds: string[] = [];

--- a/apps/cli/src/completions/zsh.ts
+++ b/apps/cli/src/completions/zsh.ts
@@ -1,5 +1,6 @@
+import { SUPPORTED_SHELLS } from '../commands/shell';
 import type { Plugin } from '../plugins/types';
-import { TOP_LEVEL_COMMANDS, commandsFor, flagsForCommand } from './shared';
+import { SHELL_ARG_COMMANDS, TOP_LEVEL_COMMANDS, commandsFor, flagsForCommand } from './shared';
 
 const esc = (s: string): string => s.replace(/'/g, "'\\''");
 
@@ -14,6 +15,12 @@ export function generateZshCompletions(plugins: readonly Plugin[]): string {
   const commandEntries = TOP_LEVEL_COMMANDS.map(
     (c) => `'${esc(c.name)}:${esc(c.description)}'`,
   ).join(' ');
+
+  // `macup completions <TAB>` should offer zsh|bash|fish, the way
+  // `--completions=<TAB>` used to from its value spec.
+  const shellCases = SHELL_ARG_COMMANDS.map(
+    (c) => `      ${c}) _values 'shell' ${SUPPORTED_SHELLS.map((sh) => `'${sh}'`).join(' ')} ;;`,
+  ).join('\n');
 
   const pluginCases = plugins
     .map((p) => {
@@ -47,14 +54,13 @@ _macup() {
   commands=(${commandEntries})
 
   # Flags are declared on _arguments so each can carry its own value
-  # spec (e.g. --completions=<shell>). Positional args 1 and 2 dispatch
-  # to the plugin / command states below.
+  # spec. Positional args 1 and 2 dispatch to the plugin / command
+  # states below.
   _arguments -C \\
     '(-h --help)'{-h,--help}'[Show help]' \\
     '(-v --version)'{-v,--version}'[Show version]' \\
     '(-V --verbose)'{-V,--verbose}'[Stream output to scrollback]' \\
     '(-D --debug)'{-D,--debug}'[Trace every shell call to stderr]' \\
-    '--completions=-[Emit completions (omit value to auto-detect)]::shell:(zsh bash fish)' \\
     '1:plugin:->plugin' \\
     '2:command:->command' \\
     '*:: :->rest'
@@ -67,6 +73,7 @@ _macup() {
     (command)
       case $words[2] in
 ${pluginCases}
+${shellCases}
       esac
       ;;
     (rest)

--- a/apps/cli/src/meta.ts
+++ b/apps/cli/src/meta.ts
@@ -117,7 +117,6 @@ const GLOBAL_FLAGS: GlobalFlagDoc[] = [
     alias: '-D',
     description: 'Full raw trace of every shell call, routed to stderr.',
   },
-  { flag: '--completions', description: 'Emit shell completions for zsh|bash|fish to stdout.' },
 ];
 
 // The stable process exit codes. A hand-maintained mirror of the exit

--- a/apps/cli/test/regression/command-nouns-not-flags.test.ts
+++ b/apps/cli/test/regression/command-nouns-not-flags.test.ts
@@ -7,6 +7,8 @@
 // the point.
 
 import { execFileSync } from 'node:child_process';
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
@@ -29,15 +31,19 @@ const NOUNS = [
   'doctor',
   'logo',
   'plugins',
+  'completions',
   'install-completions',
 ] as const;
 
-function run(args: string[]): { status: number; stderr: string; stdout: string } {
+function run(
+  args: string[],
+  env: NodeJS.ProcessEnv = {},
+): { status: number; stderr: string; stdout: string } {
   try {
     const stdout = execFileSync('node', [CLI, ...args], {
       encoding: 'utf8',
       stdio: ['ignore', 'pipe', 'pipe'],
-      env: { ...process.env, NO_COLOR: '1' },
+      env: { ...process.env, NO_COLOR: '1', ...env },
     });
     return { status: 0, stdout, stderr: '' };
   } catch (err) {
@@ -67,6 +73,43 @@ describe('regression: the old flag spellings are gone', () => {
     expect(status).toBe(1);
     expect(stderr).toContain('unknown option --bogus');
     expect(stderr).not.toContain('is now a command');
+  });
+});
+
+// The commands whose trigger arg carries a value rather than a boolean.
+// Converting them to subcommands shipped a silent no-op: the adapter
+// synthesised `true` for the trigger, so `runInstallCompletions`'s
+// `if (typeof value !== 'string') return` bailed without a word and exited
+// 0. Nothing caught it because nothing drove these end to end.
+describe('regression: the shell-taking commands actually do their work', () => {
+  it('emits a completion script for an explicit shell', () => {
+    const { status, stdout } = run(['completions', 'zsh']);
+
+    expect(status).toBe(0);
+    expect(stdout).toContain('#compdef macup');
+  });
+
+  it('auto-detects the shell when none is given', () => {
+    const { status, stdout } = run(['completions']);
+
+    // The empty trigger value means "auto-detect from $SHELL" — the thing
+    // a synthesised `true` destroyed.
+    expect(status).toBe(0);
+    expect(stdout).toContain('#compdef macup');
+  });
+
+  it('writes a file for install-completions rather than silently doing nothing', () => {
+    const home = mkdtempSync(join(tmpdir(), 'macup-xdg-'));
+    try {
+      const { status, stdout } = run(['install-completions', 'zsh'], { XDG_DATA_HOME: home });
+
+      expect(status).toBe(0);
+      expect(stdout).toContain('wrote');
+      // The assertion that would have caught the no-op: a real file.
+      expect(existsSync(join(home, 'zsh', 'site-functions', '_macup'))).toBe(true);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
   });
 });
 

--- a/apps/cli/test/regression/command-nouns-not-flags.test.ts
+++ b/apps/cli/test/regression/command-nouns-not-flags.test.ts
@@ -90,12 +90,23 @@ describe('regression: the shell-taking commands actually do their work', () => {
   });
 
   it('auto-detects the shell when none is given', () => {
-    const { status, stdout } = run(['completions']);
+    // Pin $SHELL rather than inheriting it: the assertion is about which
+    // script auto-detection picks, so the input has to be the test's, not
+    // the machine's. (CI runs under bash; a bare `expect('#compdef')` here
+    // only passed because the author's $SHELL is zsh.)
+    const { status, stdout } = run(['completions'], { SHELL: '/bin/zsh' });
 
     // The empty trigger value means "auto-detect from $SHELL" — the thing
     // a synthesised `true` destroyed.
     expect(status).toBe(0);
     expect(stdout).toContain('#compdef macup');
+  });
+
+  it('auto-detects bash just as readily', () => {
+    const { status, stdout } = run(['completions'], { SHELL: '/bin/bash' });
+
+    expect(status).toBe(0);
+    expect(stdout).toContain('complete -F _macup macup');
   });
 
   it('writes a file for install-completions rather than silently doing nothing', () => {

--- a/apps/cli/test/unit/completions/completions.test.ts
+++ b/apps/cli/test/unit/completions/completions.test.ts
@@ -73,11 +73,13 @@ describe('generateZshCompletions', () => {
     expect(out).toContain("_describe -t plugins 'package manager' plugins");
   });
 
-  it('declares global flags on _arguments (so each can carry a value spec)', () => {
-    // --completions has an optional value with a fixed shell list. It is
-    // the reason flags are declared on _arguments at all.
-    expect(out).toContain("'--completions=-[Emit completions");
-    expect(out).toContain('::shell:(zsh bash fish)');
+  it('offers the shells to the commands that take one', () => {
+    // `--completions=<shell>` got this free from its value spec. As a
+    // command (ADR 0029) the shells have to be offered explicitly, or the
+    // move would quietly cost a completion that used to work.
+    expect(out).toContain("completions) _values 'shell' 'zsh' 'bash' 'fish' ;;");
+    expect(out).toContain("install-completions) _values 'shell' 'zsh' 'bash' 'fish' ;;");
+    expect(out).toContain("init) _values 'shell' 'zsh' 'bash' 'fish' ;;");
   });
 
   it('attaches each plugin displayName as its completion description', () => {

--- a/apps/docs/content/docs/guides/shell-completions.mdx
+++ b/apps/docs/content/docs/guides/shell-completions.mdx
@@ -16,14 +16,14 @@ on the next shell start.
 
 ## Manual install
 
-`--completions` prints to stdout, for dotfiles or scripted setups:
+`macup completions` prints to stdout, for dotfiles or scripted setups:
 
 <Tabs items={['zsh', 'bash', 'fish']}>
 
 <Tab value="zsh">
 
 ```bash
-macup --completions=zsh > ~/.local/share/zsh/site-functions/_macup
+macup completions zsh > ~/.local/share/zsh/site-functions/_macup
 ```
 
 The target directory must be on your `$fpath` before `compinit` runs. After
@@ -35,7 +35,7 @@ with `exec zsh`) so the new completions load.
 <Tab value="bash">
 
 ```bash
-macup --completions=bash > ~/.local/share/bash-completion/completions/macup
+macup completions bash > ~/.local/share/bash-completion/completions/macup
 ```
 
 Requires the `bash-completion` package, which sources files from that
@@ -46,7 +46,7 @@ directory on demand. Open a new shell to pick it up.
 <Tab value="fish">
 
 ```bash
-macup --completions=fish > ~/.config/fish/completions/macup.fish
+macup completions fish > ~/.config/fish/completions/macup.fish
 ```
 
 fish loads completions from that directory automatically; no restart needed.

--- a/docs/adr/0029-command-nouns-are-subcommands.md
+++ b/docs/adr/0029-command-nouns-are-subcommands.md
@@ -27,17 +27,23 @@ compatibility with nobody and cost a permanently ambiguous interface.
 
 ## Decision
 
-The eight command nouns are citty subcommands. `macup restore` runs; `macup --restore` is an
+The nine command nouns are citty subcommands. `macup restore` runs; `macup --restore` is an
 unknown option and exits 1, with a hint naming the command to use instead.
 
-The flags that remain are the ones that really do modify a run: `--help`/`-h`, `--version`/`-v`,
-`--verbose`/`-V`, `--debug`/`-D`, plus `--completions[=<shell>]`, which takes a value and is machine
-plumbing the generated completion scripts name directly. `--version` and `--help` keep their flag
+The flags that remain are only the ones that really do modify a run: `--help`/`-h`,
+`--version`/`-v`, `--verbose`/`-V`, `--debug`/`-D`. `--version` and `--help` keep their flag
 spelling because that is the universal convention, and `macup version` stays as the one bare word
 `rewriteFlagAliases` still maps onto a flag.
 
-The `FlagAction` contract is unchanged. A small adapter in `cli.ts` turns one into the subcommand it
-should have been, dropping the trigger flag from the arg schema (invoking the subcommand is the
+`--completions[=<shell>]` was carved out at first, on the grounds that it takes a value. That was
+wrong for the same reason as the rest: taking a value does not make a thing a modifier, it makes it
+a command with an argument, which is what `macup init <shell>` already was. It became `macup
+completions <shell>` before this shipped, and the carve-out survives below only as the alternative
+it turned out to be.
+
+The `ActionCommand` contract (formerly `FlagAction`) keeps its `args`/`run` shape. A small adapter
+in `cli.ts` turns one into the subcommand it should have been, dropping the trigger arg from the
+schema (invoking the subcommand is the
 trigger) and synthesising it for `run()`. The actions, and everything that drives them directly,
 did not move.
 
@@ -54,17 +60,24 @@ did not move.
 - **Remove `--version`/`--help` too, for consistency.** Superficially tidier and actively hostile.
   Every CLI on the machine answers `--version`; being the one that doesn't is not a principled
   stand.
-- **Make `--completions` a noun as well.** Tempting for symmetry, but it takes a value
-  (`--completions=zsh`), and the generated zsh/bash/fish scripts reference it by name. The human
-  noun is `install-completions`, which did move.
+- **Keep `--completions` a flag, because it takes a value.** Considered and taken, briefly, then
+  reversed. A value-taking command is still a command: `macup init <shell>` had always been spelled
+  that way. Keeping it would have left one flag-shaped command as a permanent question, and the
+  scripts that name it are generated, so they were updated in the same change.
 
 ## Consequences
 
 - `macup --restore` now fails. Nothing published depends on it, but the author's own shell aliases
   and history might, so the unknown-option error names the replacement rather than just rejecting.
   That hint is keyed off the subcommand table, so it stays correct as commands come and go.
-- Adding a stand-alone command is now the same act as adding any other subcommand. The `FlagAction`
-  indirection remains only for `--completions`, and if that ever moves the type can go with it.
+- Adding a stand-alone command is now the same act as adding any other subcommand. With no flag
+  actions left, the `matches()` predicate and the flag-dispatch loop in `cli.ts` are gone, and
+  `FlagAction` is now `ActionCommand`, since the old name described a mechanism that no longer
+  exists.
+- The adapter reads the trigger arg's type to decide the subcommand's shape: `boolean` becomes a
+  plain command, `string` becomes one positional `[shell]`. Conflating the two is a silent no-op
+  rather than a crash, because a `true` where the shell should be makes these actions return
+  without a word, so that pairing is asserted end to end rather than by construction.
 - The list of stand-alone commands lives in `completions/shared.ts` as `TOP_LEVEL_COMMANDS`, which
   feeds both the shells and `macup/meta`, so the reference and the tab key cannot disagree. The
   `--help` screen still hand-maintains its own copy: it is prose-formatted and column-aligned, and

--- a/docs/features/shell-completions/requirements.md
+++ b/docs/features/shell-completions/requirements.md
@@ -10,10 +10,10 @@ Completions for zsh, bash, and fish are generated from the plugin manifests (PRD
 2. `--cask` and `--formula` are offered only on plugins declaring more than one subtype, and only for the subtype-aware commands.
 3. Generated scripts pass shellcheck as part of repo lint; generated files are never hand-edited.
 
-### Emission: --completions
+### Emission: `macup completions`
 
-4. `macup --completions <shell>` prints the completion source for zsh, bash, or fish to stdout, suitable for `eval "$(macup --completions zsh)"`.
-5. Bare `macup --completions` auto-detects the shell from `$SHELL`, announcing the detection on stderr so stdout stays a pure script; detection failure or an unsupported shell name errors and exits 1.
+4. `macup completions <shell>` prints the completion source for zsh, bash, or fish to stdout, suitable for `eval "$(macup completions zsh)"`.
+5. Bare `macup completions` auto-detects the shell from `$SHELL`, announcing the detection on stderr so stdout stays a pure script; detection failure or an unsupported shell name errors and exits 1.
 
 ### Installation: --install-completions
 


### PR DESCRIPTION
## What changed and why

Finishes ADR 0029, and fixes a silent no-op that ADR shipped.

**BREAKING:** `macup --completions[=<shell>]` is gone. Use `macup completions <shell>`.

```
$ macup --completions=zsh
error: unknown option --completions
    ↳ `--completions` is now a command: try `macup completions`.

$ macup completions zsh | head -1
#compdef macup
```

### The carve-out was wrong

ADR 0029 kept `--completions` a flag on the grounds that it takes a value. That's wrong for the same reason as the rest: **taking a value doesn't make a thing a modifier, it makes it a command with an argument** — which is exactly what `macup init <shell>` already was. Keeping it would have left one flag-shaped command as a permanent "why is this one different?", and the generated scripts that named it are, well, generated.

ADR 0029 is amended rather than superseded — same decision, one scoping detail reversed before any release — with the carve-out kept as the alternative it turned out to be.

### The bug ADR 0029 shipped 🐛

`macup install-completions` was a **silent no-op: printed nothing, exited 0**.

My subcommand adapter assumed every trigger arg was a boolean. But `completions` and `install-completions` carry the shell as a **string**. Synthesising `true` made this bail without a word:

```ts
const value = args['install-completions'];
if (typeof value !== 'string') return;   // ← `true` → silent return, exit 0
```

The adapter now reads the trigger's type: `boolean` stays `true`; `string` becomes a positional `[shell]`, empty meaning auto-detect, which is what these actions already read. It's the same failure shape as the bug that started this whole thread — a value replaced by the wrong type, failing quietly.

The tests missed it because nothing drove these end to end. They now do, asserting **a file on disk** rather than a return value.

### Two things that used to be free

- `--completions=<TAB>` offered `zsh|bash|fish` from its value spec. As a command that has to be explicit, so `SHELL_ARG_COMMANDS` wires it for `completions`, `install-completions` — and `init`, which never had it.
- `macup --completions zsh` (space form) **never worked**: citty takes the first non-flag token anywhere as a subcommand candidate and threw on `zsh`. I flagged this as a pre-existing bug in #67. `macup completions zsh` is a real positional, so the space form documented in `shell-completions/requirements.md` now does what it always claimed. Fixed as a side effect.

### Cleanup 0029 promised

With no flag actions left, `FlagAction` is now `ActionCommand`, and `matches()` plus the flag-dispatch loop in `cli.ts` are deleted. ADR 0029 said the type could go when the last one moved.

### Verified

`eval "$(macup completions zsh)"` in a real zsh; both generated scripts pass `zsh -n`/`bash -n`; `install-completions zsh` writes `_macup` to a temp `XDG_DATA_HOME`. 574 tests pass; lint, typecheck, build, `adr:check` and the de-slop gate are green.

## Checklist

- [x] Title and commits are Conventional Commits (`type(scope): summary`).
- [x] Lint and types pass (`pnpm lint && pnpm typecheck`).
- [x] Tests pass (`pnpm test`), and new behaviour has a test.
- [x] Build passes (`pnpm build`).