### PR TITLE
refactor: architecture-review deepening pass (8 candidates)

### DIFF
--- a/apps/cli/plugins/brew.ts
+++ b/apps/cli/plugins/brew.ts
@@ -1,4 +1,5 @@
 import { defaultCheck } from '../src/plugins/defaults';
+import { filterOutdated, mutateRefs } from '../src/plugins/helpers';
 import type {
   ListOptions,
   MutateOptions,
@@ -42,12 +43,14 @@ function parseVersionsList(stdout: string): Array<{ name: string; version?: stri
 }
 
 async function fetchFormulas(ctx: PluginContext, onlyOutdated: boolean): Promise<PackageStatus[]> {
-  const installed = parseVersionsList((await ctx.exec.run('brew', ['list', '--versions'])).stdout);
-  const outdatedRaw = await ctx.exec.runJson<OutdatedResponse>('brew', [
-    'outdated',
-    '--json=v2',
-    '--formula',
-  ]);
+  const installed = parseVersionsList(
+    (await ctx.exec.run('brew', ['list', '--versions'], { signal: ctx.signal })).stdout,
+  );
+  const outdatedRaw = await ctx.exec.runJson<OutdatedResponse>(
+    'brew',
+    ['outdated', '--json=v2', '--formula'],
+    { signal: ctx.signal },
+  );
   const outdatedMap = new Map<string, string>();
   for (const o of outdatedRaw.formulae ?? []) outdatedMap.set(o.name, o.current_version);
 
@@ -64,7 +67,7 @@ async function fetchFormulas(ctx: PluginContext, onlyOutdated: boolean): Promise
     }
     return status;
   });
-  return onlyOutdated ? result.filter((s) => s.outdated) : result;
+  return filterOutdated(result, onlyOutdated);
 }
 
 async function fetchCasks(ctx: PluginContext, onlyOutdated: boolean): Promise<PackageStatus[]> {
@@ -73,16 +76,20 @@ async function fetchCasks(ctx: PluginContext, onlyOutdated: boolean): Promise<Pa
   // single broken cask hides every other one. If the versioned form fails,
   // fall back to the names-only `brew list --cask` and report installs
   // without versions — outdated state still comes from the JSON below.
-  const versioned = await ctx.exec.run('brew', ['list', '--cask', '--versions']);
+  const versioned = await ctx.exec.run('brew', ['list', '--cask', '--versions'], {
+    signal: ctx.signal,
+  });
   const installed =
     versioned.exitCode === 0
       ? parseVersionsList(versioned.stdout)
-      : parseVersionsList((await ctx.exec.run('brew', ['list', '--cask'])).stdout);
-  const outdatedRaw = await ctx.exec.runJson<OutdatedResponse>('brew', [
-    'outdated',
-    '--json=v2',
-    '--cask',
-  ]);
+      : parseVersionsList(
+          (await ctx.exec.run('brew', ['list', '--cask'], { signal: ctx.signal })).stdout,
+        );
+  const outdatedRaw = await ctx.exec.runJson<OutdatedResponse>(
+    'brew',
+    ['outdated', '--json=v2', '--cask'],
+    { signal: ctx.signal },
+  );
   const outdatedMap = new Map<string, string>();
   for (const o of outdatedRaw.casks ?? []) {
     if (o.name) outdatedMap.set(o.name, o.current_version);
@@ -101,28 +108,12 @@ async function fetchCasks(ctx: PluginContext, onlyOutdated: boolean): Promise<Pa
     }
     return status;
   });
-  return onlyOutdated ? result.filter((s) => s.outdated) : result;
+  return filterOutdated(result, onlyOutdated);
 }
 
-async function runAll(
-  ctx: PluginContext,
-  refs: readonly PackageRef[],
-  action: 'install' | 'upgrade',
-  opts: MutateOptions,
-): Promise<void> {
-  for (const ref of refs) {
-    if (opts.dryRun) {
-      ctx.log.info(`[dry-run] brew ${action} ${ref.kind === 'cask' ? '--cask ' : ''}${ref.name}`);
-      continue;
-    }
-    const args = ref.kind === 'cask' ? [action, '--cask', ref.name] : [action, ref.name];
-    const r = await ctx.exec.run('brew', args, { signal: ctx.signal, kind: 'user-action' });
-    if (r.exitCode !== 0) {
-      throw new Error(
-        `brew ${action} ${ref.name} exited ${r.exitCode}: ${r.stderr.trim() || r.stdout.trim()}`,
-      );
-    }
-  }
+// brew needs --cask for cask refs; formulas take the bare name.
+function brewArgs(action: string, ref: PackageRef): readonly [string, readonly string[]] {
+  return ['brew', ref.kind === 'cask' ? [action, '--cask', ref.name] : [action, ref.name]];
 }
 
 const brew: Plugin = {
@@ -168,7 +159,7 @@ const brew: Plugin = {
     refs: readonly PackageRef[],
     opts: MutateOptions,
   ): Promise<void> {
-    await runAll(ctx, refs, 'install', opts);
+    await mutateRefs(ctx, refs, opts, (ref) => brewArgs('install', ref));
   },
 
   async update(
@@ -176,7 +167,7 @@ const brew: Plugin = {
     refs: readonly PackageRef[],
     opts: MutateOptions,
   ): Promise<void> {
-    await runAll(ctx, refs, 'upgrade', opts);
+    await mutateRefs(ctx, refs, opts, (ref) => brewArgs('upgrade', ref));
   },
 
   async search(ctx: PluginContext, query: string, opts?: SearchOptions): Promise<SearchResult[]> {

--- a/apps/cli/plugins/npm.ts
+++ b/apps/cli/plugins/npm.ts
@@ -1,4 +1,5 @@
 import { defaultCheck } from '../src/plugins/defaults';
+import { filterOutdated, mutateRefs, safeParseJson } from '../src/plugins/helpers';
 import type {
   ListOptions,
   MutateOptions,
@@ -23,12 +24,14 @@ type NpmOutdatedResponse = Record<string, NpmOutdatedEntry>;
 
 async function fetchStatus(ctx: PluginContext, onlyOutdated: boolean): Promise<PackageStatus[]> {
   // npm list may exit non-zero on peer-dep warnings; use run + parse manually.
-  const listResult = await ctx.exec.run('npm', ['list', '-g', '--json']);
+  const listResult = await ctx.exec.run('npm', ['list', '-g', '--json'], { signal: ctx.signal });
   const listParsed = safeParseJson<NpmListResponse>(listResult.stdout);
   const installed = listParsed?.dependencies ?? {};
 
   // npm outdated exits 1 when there ARE outdated packages. Don't treat as error.
-  const outdatedResult = await ctx.exec.run('npm', ['outdated', '-g', '--json']);
+  const outdatedResult = await ctx.exec.run('npm', ['outdated', '-g', '--json'], {
+    signal: ctx.signal,
+  });
   const outdatedParsed = safeParseJson<NpmOutdatedResponse>(outdatedResult.stdout) ?? {};
 
   const result: PackageStatus[] = Object.entries(installed).map(([name, meta]) => {
@@ -45,40 +48,7 @@ async function fetchStatus(ctx: PluginContext, onlyOutdated: boolean): Promise<P
     return status;
   });
 
-  return onlyOutdated ? result.filter((s) => s.outdated) : result;
-}
-
-function safeParseJson<T>(text: string): T | undefined {
-  const trimmed = text.trim();
-  if (!trimmed) return undefined;
-  try {
-    return JSON.parse(trimmed) as T;
-  } catch {
-    return undefined;
-  }
-}
-
-async function runAll(
-  ctx: PluginContext,
-  refs: readonly PackageRef[],
-  action: 'install' | 'update',
-  opts: MutateOptions,
-): Promise<void> {
-  for (const ref of refs) {
-    if (opts.dryRun) {
-      ctx.log.info(`[dry-run] npm ${action} -g ${ref.name}`);
-      continue;
-    }
-    const r = await ctx.exec.run('npm', [action, '-g', ref.name], {
-      signal: ctx.signal,
-      kind: 'user-action',
-    });
-    if (r.exitCode !== 0) {
-      throw new Error(
-        `npm ${action} -g ${ref.name} exited ${r.exitCode}: ${r.stderr.trim() || r.stdout.trim()}`,
-      );
-    }
-  }
+  return filterOutdated(result, onlyOutdated);
 }
 
 const npm: Plugin = {
@@ -110,7 +80,7 @@ const npm: Plugin = {
     refs: readonly PackageRef[],
     opts: MutateOptions,
   ): Promise<void> {
-    await runAll(ctx, refs, 'install', opts);
+    await mutateRefs(ctx, refs, opts, (ref) => ['npm', ['install', '-g', ref.name]]);
   },
 
   async update(
@@ -118,7 +88,7 @@ const npm: Plugin = {
     refs: readonly PackageRef[],
     opts: MutateOptions,
   ): Promise<void> {
-    await runAll(ctx, refs, 'update', opts);
+    await mutateRefs(ctx, refs, opts, (ref) => ['npm', ['update', '-g', ref.name]]);
   },
 
   async search(ctx: PluginContext, query: string): Promise<SearchResult[]> {

--- a/apps/cli/plugins/pip.ts
+++ b/apps/cli/plugins/pip.ts
@@ -1,4 +1,5 @@
 import { defaultCheck } from '../src/plugins/defaults';
+import { filterOutdated, mutateRefs } from '../src/plugins/helpers';
 import type {
   ListOptions,
   MutateOptions,
@@ -82,34 +83,14 @@ async function fetchStatus(ctx: PluginContext, onlyOutdated: boolean): Promise<P
     return status;
   });
 
-  return onlyOutdated ? result.filter((s) => s.outdated) : result;
+  return filterOutdated(result, onlyOutdated);
 }
 
-async function runAll(
-  ctx: PluginContext,
-  refs: readonly PackageRef[],
-  action: 'install' | 'update',
-  opts: MutateOptions,
-): Promise<void> {
-  // pip has no distinct "update" verb — `install --upgrade` both installs and
-  // upgrades. Only `update` passes --upgrade so a plain add doesn't force an
-  // already-satisfied package to the latest.
-  const args = action === 'update' ? ['install', '--upgrade'] : ['install'];
-  for (const ref of refs) {
-    if (opts.dryRun) {
-      ctx.log.info(`[dry-run] ${PIP} ${args.join(' ')} ${ref.name}`);
-      continue;
-    }
-    const r = await ctx.exec.run(PIP, [...args, ref.name], {
-      signal: ctx.signal,
-      kind: 'user-action',
-    });
-    if (r.exitCode !== 0) {
-      throw new Error(
-        `${PIP} ${args.join(' ')} ${ref.name} exited ${r.exitCode}: ${r.stderr.trim() || r.stdout.trim()}`,
-      );
-    }
-  }
+// pip has no distinct "update" verb — `install --upgrade` both installs and
+// upgrades. Only update passes --upgrade so a plain add doesn't force an
+// already-satisfied package to the latest.
+function pipArgs(action: 'install' | 'update', name: string): readonly [string, readonly string[]] {
+  return [PIP, action === 'update' ? ['install', '--upgrade', name] : ['install', name]];
 }
 
 const pip: Plugin = {
@@ -141,7 +122,7 @@ const pip: Plugin = {
     refs: readonly PackageRef[],
     opts: MutateOptions,
   ): Promise<void> {
-    await runAll(ctx, refs, 'install', opts);
+    await mutateRefs(ctx, refs, opts, (ref) => pipArgs('install', ref.name));
   },
 
   async update(
@@ -149,7 +130,7 @@ const pip: Plugin = {
     refs: readonly PackageRef[],
     opts: MutateOptions,
   ): Promise<void> {
-    await runAll(ctx, refs, 'update', opts);
+    await mutateRefs(ctx, refs, opts, (ref) => pipArgs('update', ref.name));
   },
 };
 

--- a/apps/cli/plugins/pnpm.ts
+++ b/apps/cli/plugins/pnpm.ts
@@ -1,4 +1,5 @@
 import { defaultCheck } from '../src/plugins/defaults';
+import { filterOutdated, mutateRefs, safeParseJson } from '../src/plugins/helpers';
 import type {
   ListOptions,
   MutateOptions,
@@ -23,18 +24,8 @@ interface PnpmOutdatedEntry {
 
 type PnpmOutdatedResponse = Record<string, PnpmOutdatedEntry>;
 
-function safeParseJson<T>(text: string): T | undefined {
-  const trimmed = text.trim();
-  if (!trimmed) return undefined;
-  try {
-    return JSON.parse(trimmed) as T;
-  } catch {
-    return undefined;
-  }
-}
-
 async function fetchStatus(ctx: PluginContext, onlyOutdated: boolean): Promise<PackageStatus[]> {
-  const listResult = await ctx.exec.run('pnpm', ['list', '-g', '--json']);
+  const listResult = await ctx.exec.run('pnpm', ['list', '-g', '--json'], { signal: ctx.signal });
   if (listResult.exitCode !== 0) {
     // Surface the failure instead of silently reporting "no packages" — the
     // query can fail for reasons the user must fix (e.g. the global bin dir
@@ -46,7 +37,9 @@ async function fetchStatus(ctx: PluginContext, onlyOutdated: boolean): Promise<P
   const installed = listParsed?.[0]?.dependencies ?? {};
 
   // pnpm outdated exits 0 even when there ARE outdated packages (unlike npm).
-  const outdatedResult = await ctx.exec.run('pnpm', ['outdated', '-g', '--json']);
+  const outdatedResult = await ctx.exec.run('pnpm', ['outdated', '-g', '--json'], {
+    signal: ctx.signal,
+  });
   const outdatedParsed = safeParseJson<PnpmOutdatedResponse>(outdatedResult.stdout) ?? {};
 
   const result: PackageStatus[] = Object.entries(installed).map(([name, meta]) => {
@@ -63,30 +56,7 @@ async function fetchStatus(ctx: PluginContext, onlyOutdated: boolean): Promise<P
     return status;
   });
 
-  return onlyOutdated ? result.filter((s) => s.outdated) : result;
-}
-
-async function runAll(
-  ctx: PluginContext,
-  refs: readonly PackageRef[],
-  action: 'add' | 'update',
-  opts: MutateOptions,
-): Promise<void> {
-  for (const ref of refs) {
-    if (opts.dryRun) {
-      ctx.log.info(`[dry-run] pnpm ${action} -g ${ref.name}`);
-      continue;
-    }
-    const r = await ctx.exec.run('pnpm', [action, '-g', ref.name], {
-      signal: ctx.signal,
-      kind: 'user-action',
-    });
-    if (r.exitCode !== 0) {
-      throw new Error(
-        `pnpm ${action} -g ${ref.name} exited ${r.exitCode}: ${r.stderr.trim() || r.stdout.trim()}`,
-      );
-    }
-  }
+  return filterOutdated(result, onlyOutdated);
 }
 
 const pnpm: Plugin = {
@@ -118,7 +88,7 @@ const pnpm: Plugin = {
     refs: readonly PackageRef[],
     opts: MutateOptions,
   ): Promise<void> {
-    await runAll(ctx, refs, 'add', opts);
+    await mutateRefs(ctx, refs, opts, (ref) => ['pnpm', ['add', '-g', ref.name]]);
   },
 
   async update(
@@ -126,7 +96,7 @@ const pnpm: Plugin = {
     refs: readonly PackageRef[],
     opts: MutateOptions,
   ): Promise<void> {
-    await runAll(ctx, refs, 'update', opts);
+    await mutateRefs(ctx, refs, opts, (ref) => ['pnpm', ['update', '-g', ref.name]]);
   },
 };
 

--- a/apps/cli/plugins/system.ts
+++ b/apps/cli/plugins/system.ts
@@ -20,7 +20,7 @@ function parseSoftwareUpdateList(stdout: string): string[] {
 }
 
 async function fetchUpdates(ctx: PluginContext): Promise<PackageStatus[]> {
-  const out = await ctx.exec.run('softwareupdate', ['-l']);
+  const out = await ctx.exec.run('softwareupdate', ['-l'], { signal: ctx.signal });
   const labels = parseSoftwareUpdateList(out.stdout);
   return labels.map((label) => ({
     ref: { kind: 'system', name: label },

--- a/apps/cli/plugins/xcode.ts
+++ b/apps/cli/plugins/xcode.ts
@@ -65,7 +65,7 @@ async function fetchXcodeApp(ctx: PluginContext): Promise<PackageStatus | undefi
 }
 
 async function fetchCommandLineTools(ctx: PluginContext): Promise<PackageStatus> {
-  const selected = await ctx.exec.run('xcode-select', ['-p']);
+  const selected = await ctx.exec.run('xcode-select', ['-p'], { signal: ctx.signal });
   if (selected.exitCode !== 0) {
     return {
       ref: { kind: 'xcode-clt', name: 'Command Line Tools' },
@@ -73,7 +73,9 @@ async function fetchCommandLineTools(ctx: PluginContext): Promise<PackageStatus>
       outdated: false,
     };
   }
-  const info = await ctx.exec.run('pkgutil', ['--pkg-info=com.apple.pkg.CLTools_Executables']);
+  const info = await ctx.exec.run('pkgutil', ['--pkg-info=com.apple.pkg.CLTools_Executables'], {
+    signal: ctx.signal,
+  });
   const version = info.exitCode === 0 ? extractCltVersion(info.stdout) : undefined;
   const status: PackageStatus = {
     ref: { kind: 'xcode-clt', name: 'Command Line Tools' },
@@ -127,7 +129,10 @@ const xcode: Plugin = {
         continue;
       }
       if (ref.kind === 'xcode-clt') {
-        await ctx.exec.run('xcode-select', ['--install'], { kind: 'user-action' });
+        await ctx.exec.run('xcode-select', ['--install'], {
+          signal: ctx.signal,
+          kind: 'user-action',
+        });
       } else {
         const r = await ctx.exec.run('mas', ['install', ref.id ?? XCODE_ID], {
           signal: ctx.signal,

--- a/apps/cli/src/cli/bootstrap.ts
+++ b/apps/cli/src/cli/bootstrap.ts
@@ -93,6 +93,7 @@ export function bootstrap(input: BootstrapInput): CliDeps {
     getStore,
     env,
     home,
+    platform: process.platform,
     signal: sigintController.signal,
     abort: () => sigintController.abort(),
   };

--- a/apps/cli/src/cli/commands.ts
+++ b/apps/cli/src/cli/commands.ts
@@ -1,0 +1,42 @@
+// The single registry of macup's top-level (stand-alone) commands — the nouns
+// that sit where a plugin id goes (ADR 0029). Dispatch is wired in cli.ts; this
+// list is what the help screen prints, what the shells complete, and what the
+// docs reference projects. One description per command, defined once here, so
+// help / completions / docs can no longer drift (they used to keep three lists,
+// and the help screen silently omitted `doctor` and `completions`).
+
+export interface TopLevelCommand {
+  readonly name: string;
+  /** One terse line. The single description used by help, completions, and docs. */
+  readonly description: string;
+  /** Positional hint shown after the name in the help label, e.g. `<shell>`. */
+  readonly argHint?: string;
+  /** Offered by shell completion. Defaults to true; `help` is not a subcommand. */
+  readonly inCompletions?: boolean;
+}
+
+export const TOP_LEVEL_COMMANDS: readonly TopLevelCommand[] = [
+  { name: 'outdated', description: 'Show outdated packages across every plugin in one pane' },
+  { name: 'check', description: 'Exit 0 if everything is current, 1 if anything is outdated' },
+  {
+    name: 'init',
+    description: 'Emit shell integration to eval from your rc file',
+    argHint: '<shell>',
+  },
+  { name: 'doctor', description: 'Run a self-diagnostic report' },
+  { name: 'config', description: 'Show config path, schema, and pin/skip counts' },
+  { name: 'plugins', description: 'List built-in plugins and their availability' },
+  { name: 'cleanup', description: 'Delete all backup files' },
+  { name: 'restore', description: 'Restore the applist from a backup' },
+  { name: 'undo', description: 'Revert to the most recent backup (diff first)' },
+  { name: 'completions', description: 'Emit shell completions to stdout', argHint: '<shell>' },
+  { name: 'install-completions', description: 'Install shell completions (auto-detects shell)' },
+  { name: 'version', description: 'Show version with logo' },
+  { name: 'logo', description: 'Print the Apple logo' },
+  { name: 'help', description: 'Show this help screen', inCompletions: false },
+];
+
+/** The subset the shells complete: every top-level command except `help`. */
+export const COMPLETABLE_COMMANDS: readonly TopLevelCommand[] = TOP_LEVEL_COMMANDS.filter(
+  (c) => c.inCompletions !== false,
+);

--- a/apps/cli/src/cli/help.ts
+++ b/apps/cli/src/cli/help.ts
@@ -11,6 +11,7 @@ import pc from 'picocolors';
 import * as logui from '../ui/log';
 import { page } from '../ui/pager';
 import { getVersion } from '../version';
+import { TOP_LEVEL_COMMANDS } from './commands';
 import type { CliDeps } from './types';
 
 export function printVersionSplash(deps: CliDeps): void {
@@ -89,28 +90,14 @@ export function buildHelp(deps: CliDeps): string {
   say(cols(pluginRows));
   say('');
 
-  // Top-level (cross-plugin) commands.
+  // Top-level (cross-plugin) commands, projected from the one registry
+  // (src/cli/commands.ts) so this screen can't drift from completions and docs,
+  // and can't silently omit a real command the way the hand-written list did.
   say(`${logui.header('COMMANDS')} ${s.dim('Stand-alone commands')}`);
-  const commandRows: logui.ColumnRow[] = [
-    { label: 'outdated', desc: 'Show outdated packages across every plugin in one pane [--json]' },
-    {
-      label: 'check',
-      desc: 'Exit 0 if everything is current, 1 if anything is outdated [--quiet]',
-    },
-    {
-      label: 'init <shell>',
-      desc: 'Emit shell integration (zsh|bash|fish) to eval from your rc file',
-    },
-    { label: 'version', desc: 'Show version with logo' },
-    { label: 'help', desc: 'Show this help screen' },
-    { label: 'config', desc: 'Show config path, schema, pins/skip counts' },
-    { label: 'cleanup', desc: 'Delete all backup files' },
-    { label: 'restore', desc: 'Restore config from a backup' },
-    { label: 'undo', desc: 'Revert to the most recent backup (diff first)' },
-    { label: 'logo', desc: 'Print the Apple logo' },
-    { label: 'plugins', desc: 'List built-in plugins and their availability' },
-    { label: 'install-completions', desc: 'Install shell completions (auto-detects shell)' },
-  ].map((r) => ({ label: s.bold(r.label), desc: r.desc }));
+  const commandRows: logui.ColumnRow[] = TOP_LEVEL_COMMANDS.map((c) => ({
+    label: s.bold(c.argHint ? `${c.name} ${c.argHint}` : c.name),
+    desc: c.description,
+  }));
   say(cols(commandRows));
   say('');
 

--- a/apps/cli/src/cli/types.ts
+++ b/apps/cli/src/cli/types.ts
@@ -37,6 +37,8 @@ export interface CliDeps {
   readonly getStore: () => Promise<ConfigStore>;
   readonly env: NodeJS.ProcessEnv;
   readonly home: string;
+  /** Host platform, resolved once at startup so commands don't read process.platform. */
+  readonly platform: NodeJS.Platform;
   /** Process-wide cancellation signal. Aborted on SIGINT by cli.ts. */
   readonly signal: AbortSignal;
   /** Trip the cancellation signal. Used by the SIGINT handler. */

--- a/apps/cli/src/commands/doctor/checks/data-integrity.ts
+++ b/apps/cli/src/commands/doctor/checks/data-integrity.ts
@@ -15,20 +15,18 @@ import type { CheckDeps, CheckResult, Section } from '../report';
 import { missingBinaries, probeList } from './probe';
 
 function trackedFor(applist: Applist, key: ApplistKey): readonly string[] {
-  switch (key) {
-    case 'appstore':
-      return applist.appstore;
-    case 'npm':
-      return applist.npm;
-    case 'pnpm':
-      return applist.pnpm;
-    case 'pip':
-      return applist.pip;
-    case 'brew.formulas':
-      return applist.brew.formulas;
-    case 'brew.casks':
-      return applist.brew.casks;
-  }
+  // Walk the dotted applist key generically (e.g. 'brew.formulas' resolves
+  // applist.brew.formulas), so this reader needs no per-key case and a new
+  // plugin's config key does not force an edit here. The applist schema
+  // (config/schema.ts) stays the one place the key set is declared.
+  const value = key
+    .split('.')
+    .reduce<unknown>(
+      (node, seg) =>
+        node && typeof node === 'object' ? (node as Record<string, unknown>)[seg] : undefined,
+      applist,
+    );
+  return Array.isArray(value) ? (value as readonly string[]) : [];
 }
 
 // Same permissive stance as src/plugins/selection.ts: pins can be

--- a/apps/cli/src/commands/from-manifest.ts
+++ b/apps/cli/src/commands/from-manifest.ts
@@ -40,6 +40,27 @@ async function trySave(store: ConfigStore, operation: string): Promise<SaveResul
   }
 }
 
+/**
+ * The mutate → save → report protocol every config verb (track, untrack, pin,
+ * unpin, skip, unskip) runs: load the store, apply the mutation, save with a
+ * friendly error, then report success and echo the backup path. Callers supply
+ * only the mutation and how to describe its result; the invariant tail lived in
+ * all six verbs before.
+ */
+async function commitMutation<T>(
+  deps: CommandDeps,
+  operation: string,
+  apply: (store: ConfigStore) => T,
+  report: (result: T) => void,
+): Promise<void> {
+  const store = await deps.getStore();
+  const result = apply(store);
+  const save = await trySave(store, operation);
+  if (!save) return;
+  report(result);
+  if (save.backupPath) console.log(log.trace(`Backup: ${save.backupPath}`));
+}
+
 async function runHealthCheck(
   deps: SpinnerDeps,
   pluginId: string,
@@ -500,29 +521,31 @@ export function commandsFromManifest(plugin: Plugin, deps: CommandDeps): Command
         const subtype = resolved.subtype;
         const names = requireNames(rawArgs, manifest.id, 'track');
         if (!names) return;
-        const store = await deps.getStore();
         const key = resolveConfigKey(plugin, subtype);
-        const result = store.add(key, names);
-        const save = await trySave(store, 'track');
-        if (!save) return;
-        if (result.added.length > 0) {
-          console.log(log.success(`Tracked in ${key}: ${result.added.join(', ')}`));
-          if (result.skipped.length > 0) {
-            console.log(log.info(`Already tracked: ${result.skipped.join(', ')}`));
-          }
-        } else {
-          // Every name was already tracked. Echo them and suggest install
-          // (the action a user typing `track <name>` is most likely after).
-          console.log(log.info(`Already tracked in ${key}: ${result.skipped.join(', ')}`));
-          if (manifest.capabilities.install) {
-            console.log(
-              log.trace(
-                `macup ${manifest.id} install ${subtypeCliFlag(subtype)}${result.skipped.join(' ')}`,
-              ),
-            );
-          }
-        }
-        if (save.backupPath) console.log(log.trace(`Backup: ${save.backupPath}`));
+        await commitMutation(
+          deps,
+          'track',
+          (store) => store.add(key, names),
+          (result) => {
+            if (result.added.length > 0) {
+              console.log(log.success(`Tracked in ${key}: ${result.added.join(', ')}`));
+              if (result.skipped.length > 0) {
+                console.log(log.info(`Already tracked: ${result.skipped.join(', ')}`));
+              }
+            } else {
+              // Every name was already tracked. Echo them and suggest install
+              // (the action a user typing `track <name>` is most likely after).
+              console.log(log.info(`Already tracked in ${key}: ${result.skipped.join(', ')}`));
+              if (manifest.capabilities.install) {
+                console.log(
+                  log.trace(
+                    `macup ${manifest.id} install ${subtypeCliFlag(subtype)}${result.skipped.join(' ')}`,
+                  ),
+                );
+              }
+            }
+          },
+        );
       },
     });
   }
@@ -548,27 +571,29 @@ export function commandsFromManifest(plugin: Plugin, deps: CommandDeps): Command
         const subtype = resolved.subtype;
         const names = requireNames(rawArgs, manifest.id, 'untrack');
         if (!names) return;
-        const store = await deps.getStore();
         const key = resolveConfigKey(plugin, subtype);
-        const result = store.remove(key, names);
-        const save = await trySave(store, 'untrack');
-        if (!save) return;
-        if (result.removed.length > 0) {
-          console.log(log.success(`Untracked from ${key}: ${result.removed.join(', ')}`));
-          if (result.missing.length > 0) {
-            console.log(log.info(`Not present: ${result.missing.join(', ')}`));
-          }
-        } else {
-          // Nothing matched. Echo the names so the user sees what they
-          // typed and point at `list` to find the tracked equivalents.
-          console.log(log.info(`Not tracked in ${key}: ${result.missing.join(', ')}`));
-          if (manifest.capabilities.list) {
-            console.log(
-              log.trace(`macup ${manifest.id} list ${subtypeCliFlag(subtype)}`.trimEnd()),
-            );
-          }
-        }
-        if (save.backupPath) console.log(log.trace(`Backup: ${save.backupPath}`));
+        await commitMutation(
+          deps,
+          'untrack',
+          (store) => store.remove(key, names),
+          (result) => {
+            if (result.removed.length > 0) {
+              console.log(log.success(`Untracked from ${key}: ${result.removed.join(', ')}`));
+              if (result.missing.length > 0) {
+                console.log(log.info(`Not present: ${result.missing.join(', ')}`));
+              }
+            } else {
+              // Nothing matched. Echo the names so the user sees what they
+              // typed and point at `list` to find the tracked equivalents.
+              console.log(log.info(`Not tracked in ${key}: ${result.missing.join(', ')}`));
+              if (manifest.capabilities.list) {
+                console.log(
+                  log.trace(`macup ${manifest.id} list ${subtypeCliFlag(subtype)}`.trimEnd()),
+                );
+              }
+            }
+          },
+        );
       },
     });
   }
@@ -592,12 +617,12 @@ export function commandsFromManifest(plugin: Plugin, deps: CommandDeps): Command
           return;
         }
         const [name, version] = positionals as [string, string];
-        const store = await deps.getStore();
-        store.pin(manifest.id, name, version);
-        const save = await trySave(store, 'pin');
-        if (!save) return;
-        console.log(log.success(`Pinned ${name} to ${version} (${manifest.id})`));
-        if (save.backupPath) console.log(log.trace(`Backup: ${save.backupPath}`));
+        await commitMutation(
+          deps,
+          'pin',
+          (store) => store.pin(manifest.id, name, version),
+          () => console.log(log.success(`Pinned ${name} to ${version} (${manifest.id})`)),
+        );
       },
     });
 
@@ -609,12 +634,12 @@ export function commandsFromManifest(plugin: Plugin, deps: CommandDeps): Command
       async run({ rawArgs }) {
         const names = requireNames(rawArgs, manifest.id, 'unpin');
         if (!names) return;
-        const store = await deps.getStore();
-        store.unpin(manifest.id, names[0] as string);
-        const save = await trySave(store, 'unpin');
-        if (!save) return;
-        console.log(log.success(`Unpinned ${names[0]} (${manifest.id})`));
-        if (save.backupPath) console.log(log.trace(`Backup: ${save.backupPath}`));
+        await commitMutation(
+          deps,
+          'unpin',
+          (store) => store.unpin(manifest.id, names[0] as string),
+          () => console.log(log.success(`Unpinned ${names[0]} (${manifest.id})`)),
+        );
       },
     });
 
@@ -626,12 +651,13 @@ export function commandsFromManifest(plugin: Plugin, deps: CommandDeps): Command
       async run({ rawArgs }) {
         const names = requireNames(rawArgs, manifest.id, 'skip');
         if (!names) return;
-        const store = await deps.getStore();
-        store.skip(manifest.id, names);
-        const save = await trySave(store, 'skip');
-        if (!save) return;
-        console.log(log.success(`Skipped from ${manifest.id} updates: ${names.join(', ')}`));
-        if (save.backupPath) console.log(log.trace(`Backup: ${save.backupPath}`));
+        await commitMutation(
+          deps,
+          'skip',
+          (store) => store.skip(manifest.id, names),
+          () =>
+            console.log(log.success(`Skipped from ${manifest.id} updates: ${names.join(', ')}`)),
+        );
       },
     });
 
@@ -643,12 +669,12 @@ export function commandsFromManifest(plugin: Plugin, deps: CommandDeps): Command
       async run({ rawArgs }) {
         const names = requireNames(rawArgs, manifest.id, 'unskip');
         if (!names) return;
-        const store = await deps.getStore();
-        store.unskip(manifest.id, names);
-        const save = await trySave(store, 'unskip');
-        if (!save) return;
-        console.log(log.success(`Unskipped (${manifest.id}): ${names.join(', ')}`));
-        if (save.backupPath) console.log(log.trace(`Backup: ${save.backupPath}`));
+        await commitMutation(
+          deps,
+          'unskip',
+          (store) => store.unskip(manifest.id, names),
+          () => console.log(log.success(`Unskipped (${manifest.id}): ${names.join(', ')}`)),
+        );
       },
     });
   }

--- a/apps/cli/src/commands/outdated.ts
+++ b/apps/cli/src/commands/outdated.ts
@@ -225,7 +225,7 @@ export function buildOutdatedCommand(deps: CliDeps) {
         makeCtx: () => ({
           exec: deps.exec,
           log: deps.log,
-          signal: new AbortController().signal,
+          signal: deps.signal,
         }),
         onProgress: (e) => {
           s?.message(`Checking plugins… (${e.completed}/${e.total}) ${e.displayName}`);

--- a/apps/cli/src/commands/outdated.ts
+++ b/apps/cli/src/commands/outdated.ts
@@ -3,6 +3,7 @@ import { defineCommand } from 'citty';
 import type { CliDeps } from '../cli/types';
 import { ErrPluginUnavailable } from '../errors';
 import type { PackageStatus, Plugin, PluginContext } from '../plugins/types';
+import { painter } from '../ui/color';
 
 export interface OutdatedPluginSummary {
   pluginId: string;
@@ -133,15 +134,14 @@ export function formatOutdatedHeader(opts: { color?: boolean } = {}): string {
   const color = opts.color ?? false;
   const label = ' OUTDATED ';
   if (!color) return `\n  ${label.trim()}\n`;
-  return `\n  \x1b[33m\x1b[7m\x1b[1m${label}\x1b[0m\n`;
+  const c = painter(color);
+  return `\n  ${c.yellow(c.inverse(c.bold(label)))}\n`;
 }
 
 export function formatOutdatedReport(report: OutdatedReport, opts: FormatOptions = {}): string {
   const color = opts.color ?? false;
   const maxNames = opts.maxNames ?? 6;
-  const green = (s: string) => (color ? `\x1b[32m${s}\x1b[0m` : s);
-  const yellow = (s: string) => (color ? `\x1b[33m${s}\x1b[0m` : s);
-  const dim = (s: string) => (color ? `\x1b[2m${s}\x1b[0m` : s);
+  const { green, yellow, dim } = painter(color);
 
   const idPad = Math.max(4, ...report.plugins.map((p) => p.pluginId.length));
 

--- a/apps/cli/src/commands/plugins.ts
+++ b/apps/cli/src/commands/plugins.ts
@@ -1,5 +1,4 @@
 import type { ActionCommand, CliDeps, ParsedArgs } from '../cli/types';
-import { BUILTIN_PLUGINS, isOnPath } from '../plugins/registry';
 import type { Plugin, PluginCapabilities } from '../plugins/types';
 import { painter } from '../ui/color';
 
@@ -131,9 +130,9 @@ export function formatPluginsReport(report: PluginsReport, opts: FormatOptions =
 }
 
 export async function runPlugins(_args: ParsedArgs, deps: CliDeps): Promise<void> {
-  const report = buildPluginsReport(BUILTIN_PLUGINS, {
-    platform: process.platform,
-    onPath: (b) => isOnPath(b),
+  const report = buildPluginsReport(deps.registry, {
+    platform: deps.platform,
+    onPath: (b) => deps.exec.onPath(b),
   });
   console.log(formatPluginsReport(report, { color: deps.color }));
 }

--- a/apps/cli/src/commands/plugins.ts
+++ b/apps/cli/src/commands/plugins.ts
@@ -1,6 +1,7 @@
 import type { ActionCommand, CliDeps, ParsedArgs } from '../cli/types';
 import { BUILTIN_PLUGINS, isOnPath } from '../plugins/registry';
 import type { Plugin, PluginCapabilities } from '../plugins/types';
+import { painter } from '../ui/color';
 
 export interface PluginStatus {
   id: string;
@@ -91,9 +92,7 @@ export interface FormatOptions {
  */
 export function formatPluginsReport(report: PluginsReport, opts: FormatOptions = {}): string {
   const color = opts.color ?? false;
-  const green = (s: string) => (color ? `\x1b[32m${s}\x1b[0m` : s);
-  const red = (s: string) => (color ? `\x1b[31m${s}\x1b[0m` : s);
-  const dim = (s: string) => (color ? `\x1b[2m${s}\x1b[0m` : s);
+  const { green, red, dim } = painter(color);
 
   const idPad = Math.max(4, ...report.statuses.map((s) => s.id.length));
   const namePad = Math.max(4, ...report.statuses.map((s) => s.displayName.length));

--- a/apps/cli/src/completions/shared.ts
+++ b/apps/cli/src/completions/shared.ts
@@ -1,3 +1,4 @@
+import { COMPLETABLE_COMMANDS } from '../cli/commands';
 import type { Plugin } from '../plugins/types';
 
 /**
@@ -5,24 +6,12 @@ import type { Plugin } from '../plugins/types';
  * position: `macup restore`, `macup outdated`. These are nouns, not flags
  * (ADR 0029), so completion offers them where a plugin id would go.
  *
- * Mirrors the subcommands wired in src/cli.ts — that file is the source of
- * truth for dispatch, this is the source of truth for what shells offer.
+ * Projected from the single top-level command registry (src/cli/commands.ts);
+ * `help` is excluded because it is not a dispatched subcommand. cli.ts is the
+ * source of truth for dispatch, the registry for descriptions, and this view
+ * for what the shells offer.
  */
-export const TOP_LEVEL_COMMANDS: ReadonlyArray<{ name: string; description: string }> = [
-  { name: 'outdated', description: 'Show outdated packages across every plugin' },
-  { name: 'check', description: 'Exit 0 if current, 1 if anything is outdated' },
-  { name: 'init', description: 'Emit shell integration to eval from your rc file' },
-  { name: 'doctor', description: 'Run a self-diagnostic report' },
-  { name: 'config', description: 'Show config status' },
-  { name: 'plugins', description: 'List built-in plugins and availability' },
-  { name: 'cleanup', description: 'Delete all config backup files' },
-  { name: 'restore', description: 'Restore the applist from a backup' },
-  { name: 'undo', description: 'Revert to the most recent backup' },
-  { name: 'completions', description: 'Emit shell completions to stdout' },
-  { name: 'install-completions', description: 'Install shell completions' },
-  { name: 'version', description: 'Show version with logo' },
-  { name: 'logo', description: 'Print the Apple logo' },
-];
+export const TOP_LEVEL_COMMANDS = COMPLETABLE_COMMANDS;
 
 /**
  * Commands whose one positional is a shell name. `--completions=<shell>`

--- a/apps/cli/src/exec/on-path.ts
+++ b/apps/cli/src/exec/on-path.ts
@@ -1,0 +1,34 @@
+// Where does a binary resolve on $PATH? A leaf utility depending only on node's
+// fs/path, so the low-level exec runner can answer "is this on PATH?" without
+// importing the plugin registry (which imports every plugin). run.ts used to
+// reach up into plugins/registry for this — an inversion from the lowest layer
+// to the highest. The registry now re-exports these for its own PATH filtering
+// and the doctor report.
+
+import { constants, accessSync } from 'node:fs';
+import { delimiter, join } from 'node:path';
+
+/**
+ * Minimal `which`-style lookup: the first $PATH entry where `binary` exists as
+ * an executable, or undefined. `--doctor` uses the resolved path in its plugin
+ * report lines.
+ */
+export function pathTo(binary: string, env: NodeJS.ProcessEnv = process.env): string | undefined {
+  const pathValue = env.PATH ?? '';
+  const paths = pathValue.split(delimiter).filter(Boolean);
+  for (const dir of paths) {
+    try {
+      const candidate = join(dir, binary);
+      accessSync(candidate, constants.X_OK);
+      return candidate;
+    } catch {
+      // keep searching
+    }
+  }
+  return undefined;
+}
+
+/** Boolean form of `pathTo`. */
+export function isOnPath(binary: string, env: NodeJS.ProcessEnv = process.env): boolean {
+  return pathTo(binary, env) !== undefined;
+}

--- a/apps/cli/src/exec/run.ts
+++ b/apps/cli/src/exec/run.ts
@@ -1,6 +1,6 @@
 import { ExecaError, execa } from 'execa';
-import { isOnPath } from '../plugins/registry';
 import type { ExecResult, ExecRunOptions, ExecRunner } from '../plugins/types';
+import { isOnPath } from './on-path';
 
 export class ExecaExecRunner implements ExecRunner {
   async run(cmd: string, args: readonly string[], opts: ExecRunOptions = {}): Promise<ExecResult> {

--- a/apps/cli/src/plugins/helpers.ts
+++ b/apps/cli/src/plugins/helpers.ts
@@ -1,0 +1,63 @@
+// Shared plumbing for plugin implementations. These are the loop, the filter,
+// and the JSON parse that every package-manager plugin needs. They used to be
+// copied into each plugin (the mutate loop six times, the onlyOutdated filter
+// seven times, the JSON parser twice verbatim), which is where the dropped
+// ctx.signal and the divergent error strings crept in. Owning them once keeps
+// the plugins to just the per-manager knowledge: which argv to run.
+
+import type { MutateOptions, PackageRef, PackageStatus, PluginContext } from './types';
+
+/**
+ * Tolerant JSON parse for tool output that may be empty or noisy. Returns
+ * undefined instead of throwing, so a plugin can fall back rather than abort —
+ * npm and pnpm `outdated` exit non-zero and still emit useful JSON.
+ */
+export function safeParseJson<T>(text: string): T | undefined {
+  const trimmed = text.trim();
+  if (!trimmed) return undefined;
+  try {
+    return JSON.parse(trimmed) as T;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Apply the `ListOptions.onlyOutdated` contract in one place. Plugins build the
+ * full status list and hand it here rather than each re-implementing the tail
+ * filter (they did, seven times, one of them subtly differently).
+ */
+export function filterOutdated(
+  statuses: readonly PackageStatus[],
+  onlyOutdated: boolean,
+): PackageStatus[] {
+  return onlyOutdated ? statuses.filter((s) => s.outdated) : [...statuses];
+}
+
+/**
+ * Run a mutating command once per package ref. The loop that used to live in
+ * every plugin's `runAll` lives here: honour `dryRun`, pass the cancellation
+ * signal, tag output as a `user-action` so it lands in the status-bar pane,
+ * and throw a uniform error on a non-zero exit. A plugin supplies only the
+ * argv for a ref via `command`.
+ */
+export async function mutateRefs(
+  ctx: PluginContext,
+  refs: readonly PackageRef[],
+  opts: MutateOptions,
+  command: (ref: PackageRef) => readonly [string, readonly string[]],
+): Promise<void> {
+  for (const ref of refs) {
+    const [cmd, args] = command(ref);
+    if (opts.dryRun) {
+      ctx.log.info(`[dry-run] ${cmd} ${args.join(' ')}`);
+      continue;
+    }
+    const r = await ctx.exec.run(cmd, args, { signal: ctx.signal, kind: 'user-action' });
+    if (r.exitCode !== 0) {
+      throw new Error(
+        `${cmd} ${args.join(' ')} exited ${r.exitCode}: ${r.stderr.trim() || r.stdout.trim()}`,
+      );
+    }
+  }
+}

--- a/apps/cli/src/plugins/registry.ts
+++ b/apps/cli/src/plugins/registry.ts
@@ -1,5 +1,3 @@
-import { constants, accessSync } from 'node:fs';
-import { delimiter, join } from 'node:path';
 import { createAllPlugin } from '../../plugins/all';
 import appstorePlugin from '../../plugins/appstore';
 import brewPlugin from '../../plugins/brew';
@@ -8,6 +6,7 @@ import pipPlugin from '../../plugins/pip';
 import pnpmPlugin from '../../plugins/pnpm';
 import systemPlugin from '../../plugins/system';
 import xcodePlugin from '../../plugins/xcode';
+import { isOnPath, pathTo } from '../exec/on-path';
 import type { Plugin } from './types';
 
 export interface RegistryDeps {
@@ -30,33 +29,10 @@ export function buildRegistry(plugins: readonly Plugin[], deps: RegistryDeps): P
   });
 }
 
-/**
- * Minimal `which`-style lookup: the first $PATH entry where `binary`
- * exists as an executable, or undefined. `--doctor` uses the resolved
- * path in its plugin report lines.
- */
-export function pathTo(binary: string, env: NodeJS.ProcessEnv = process.env): string | undefined {
-  const pathValue = env.PATH ?? '';
-  const paths = pathValue.split(delimiter).filter(Boolean);
-  for (const dir of paths) {
-    try {
-      const candidate = join(dir, binary);
-      accessSync(candidate, constants.X_OK);
-      return candidate;
-    } catch {
-      // keep searching
-    }
-  }
-  return undefined;
-}
-
-/**
- * Boolean form of pathTo. Used as the default onPath for the registry;
- * tests can override by passing a custom onPath.
- */
-export function isOnPath(binary: string, env: NodeJS.ProcessEnv = process.env): boolean {
-  return pathTo(binary, env) !== undefined;
-}
+// isOnPath / pathTo live in src/exec/on-path.ts (a leaf module with no plugin
+// imports) so exec/run.ts can do its PATH lookup without importing the registry.
+// Re-exported here for the existing consumers (doctor report, buildRegistry).
+export { isOnPath, pathTo };
 
 /**
  * The closed set of built-in plugins. Adding a new plugin = one import

--- a/apps/cli/src/ui/color.ts
+++ b/apps/cli/src/ui/color.ts
@@ -1,0 +1,40 @@
+import pc from 'picocolors';
+
+// Force-enabled palette. The caller has already resolved whether colour is on
+// (CliDeps.color, from NO_COLOR + isTTY), so picocolors must not second-guess
+// it with its own TTY detection — that would drop escapes under a pipe or in
+// tests. createColors(true) always emits; the painter gates on the resolved
+// boolean instead.
+const forced = pc.createColors(true);
+
+export interface Painter {
+  green(s: string): string;
+  yellow(s: string): string;
+  red(s: string): string;
+  dim(s: string): string;
+  bold(s: string): string;
+  inverse(s: string): string;
+}
+
+/**
+ * A colour painter gated on an already-resolved boolean. Commands that receive
+ * the colour decision as data (`CliDeps.color`, resolved once in bootstrap)
+ * paint through this instead of hand-rolling raw `\x1b[` escapes, so every
+ * styled byte goes through picocolors and honours `NO_COLOR` the same way the
+ * rest of the UI does. `CODING_STANDARDS.md` requires output to go through the
+ * UI layer rather than bypass it with raw escapes.
+ */
+export function painter(enabled: boolean): Painter {
+  const gate =
+    (fn: (s: string) => string) =>
+    (s: string): string =>
+      enabled ? fn(s) : s;
+  return {
+    green: gate(forced.green),
+    yellow: gate(forced.yellow),
+    red: gate(forced.red),
+    dim: gate(forced.dim),
+    bold: gate(forced.bold),
+    inverse: gate(forced.inverse),
+  };
+}

--- a/apps/cli/src/ui/log.ts
+++ b/apps/cli/src/ui/log.ts
@@ -1,6 +1,12 @@
 import pc from 'picocolors';
 import { useColor as useColorFn } from '../runtime';
 import { renderAppleLogo } from './logo';
+import { visualWidth } from './width';
+
+// Re-exported so existing importers (ui/pager, ui/picker, tests) keep importing
+// visualWidth from ui/log; the implementation now lives in ui/width, shared
+// with the status bar so there is one ANSI-strip + width definition.
+export { visualWidth };
 
 // Lazy boolean read on every styled-glyph emit, so this module can be
 // imported before stdout/NO_COLOR are settled (e.g. in test harnesses).
@@ -124,65 +130,9 @@ export function error(msg: string): string {
   return `  ${SYM.error} ${useColorFn() ? pc.red(msg) : msg}`;
 }
 
-// ── Branded version display ─────────────────────────────────────
-
-export function versionBlock(opts: {
-  version: string;
-  description: string;
-  author: string;
-  homepage: string;
-}): string {
-  const lines: string[] = [];
-  // Logo wordmark: inverse-video bold green pill, e.g. " macup v1.0.0 "
-  const badgeText = ` macup v${opts.version} `;
-  const badge = useColorFn() ? pc.inverse(pc.bold(pc.green(badgeText))) : badgeText.trim();
-  lines.push('');
-  lines.push(`  ${badge}`);
-  lines.push('');
-  lines.push(`  ${useColorFn() ? pc.dim(opts.description) : opts.description}`);
-  lines.push('');
-  lines.push(`  ${SYM.bullet} Author:   ${opts.author}`);
-  lines.push(
-    `  ${SYM.bullet} Homepage: ${useColorFn() ? pc.underline(opts.homepage) : opts.homepage}`,
-  );
-  lines.push('');
-  return lines.join('\n');
-}
-
 export { SYM };
 
 // ── Layout helpers ──────────────────────────────────────────────
-
-const ANSI_RE = new RegExp(`${String.fromCharCode(0x1b)}\\[[0-9;]*m`, 'g');
-
-/**
- * Visual cell width of a string after stripping ANSI, counting basic
- * CJK/fullwidth codepoints as 2 cells so our logo aligns correctly.
- * Not a full Unicode width implementation — just enough for the chars
- * this project uses.
- */
-export function visualWidth(s: string): number {
-  const stripped = s.replace(ANSI_RE, '');
-  let w = 0;
-  for (const ch of stripped) {
-    const cp = ch.codePointAt(0) ?? 0;
-    // Rough fullwidth ranges: CJK symbols/punct, CJK unified, fullwidth forms.
-    const fullwidth =
-      (cp >= 0x1100 && cp <= 0x115f) ||
-      (cp >= 0x2e80 && cp <= 0x303f) ||
-      (cp >= 0x3041 && cp <= 0x33ff) ||
-      (cp >= 0x3400 && cp <= 0x4dbf) ||
-      (cp >= 0x4e00 && cp <= 0x9fff) ||
-      (cp >= 0xa000 && cp <= 0xa4cf) ||
-      (cp >= 0xac00 && cp <= 0xd7a3) ||
-      (cp >= 0xf900 && cp <= 0xfaff) ||
-      (cp >= 0xfe30 && cp <= 0xfe4f) ||
-      (cp >= 0xff00 && cp <= 0xff60) ||
-      (cp >= 0xffe0 && cp <= 0xffe6);
-    w += fullwidth ? 2 : 1;
-  }
-  return w;
-}
 
 /**
  * Zip two multi-line strings into two columns. Shorter block is padded

--- a/apps/cli/src/ui/logo.ts
+++ b/apps/cli/src/ui/logo.ts
@@ -108,7 +108,7 @@ export function renderAppleLogo(opts: LogoRenderOptions = {}): string {
  * Rendered credits block for the interactive splash — author line and
  * repo URL, all lowercase, dimmed to sit quietly beneath the Apple logo.
  * Kept separate from the branded --version output (which uses titlecase +
- * bullets in src/ui/log.ts:versionBlock) so the splash stays understated.
+ * bullets in src/ui/log.ts:splashBlock) so the splash stays understated.
  */
 export interface CreditsRenderOptions {
   color?: boolean;

--- a/apps/cli/src/ui/status-bar.ts
+++ b/apps/cli/src/ui/status-bar.ts
@@ -11,7 +11,7 @@
 
 import pc from 'picocolors';
 import { useColor } from '../runtime';
-import { stripAnsi, visualWidth } from './width';
+import { clipToWidth, stripAnsi, visualWidth } from './width';
 
 export interface StatusBarOptions {
   readonly color?: boolean;
@@ -29,12 +29,11 @@ const SPINNER_FRAMES = ['◐', '◓', '◑', '◒'] as const;
 function clipOrPad(line: string, width: number): string {
   const clean = stripAnsi(line);
   const w = visualWidth(clean);
-  if (w === width) return clean;
-  if (w > width) {
-    const arr = [...clean];
-    return `${arr.slice(0, Math.max(0, width - 1)).join('')}…`;
-  }
-  return clean + ' '.repeat(width - w);
+  if (w <= width) return clean + ' '.repeat(width - w);
+  // Clip by cell width, then pad in case the last fullwidth cell didn't fit,
+  // so the box-pane column stays exactly `width` cells wide.
+  const clipped = clipToWidth(clean, width);
+  return clipped + ' '.repeat(Math.max(0, width - visualWidth(clipped)));
 }
 
 export class StatusBar {
@@ -203,7 +202,7 @@ export class StatusBar {
     const frame = SPINNER_FRAMES[this.frameIdx];
     const tail = this.suffix.length > 0 ? `  ${this.suffix}` : '';
     const text = `${frame}  ${this.message}${tail}`;
-    const truncated = visualWidth(text) > cols ? `${text.slice(0, cols - 1)}…` : text;
+    const truncated = clipToWidth(text, cols);
     const styled = this.color ? pc.cyan(truncated) : truncated;
     this.out.write(`\x1b7\x1b[${rows};1H\x1b[2K${styled}\x1b8`);
   }

--- a/apps/cli/src/ui/status-bar.ts
+++ b/apps/cli/src/ui/status-bar.ts
@@ -11,6 +11,7 @@
 
 import pc from 'picocolors';
 import { useColor } from '../runtime';
+import { stripAnsi, visualWidth } from './width';
 
 export interface StatusBarOptions {
   readonly color?: boolean;
@@ -25,19 +26,9 @@ export interface StatusBarOptions {
 
 const SPINNER_FRAMES = ['◐', '◓', '◑', '◒'] as const;
 
-// biome-ignore lint/suspicious/noControlCharactersInRegex: stripping ANSI on purpose
-const ANSI_REGEX = /\x1b\[[0-9;?]*[A-Za-z]/g;
-function stripAnsi(s: string): string {
-  return s.replace(ANSI_REGEX, '');
-}
-
-function visualLen(s: string): number {
-  return [...stripAnsi(s)].length;
-}
-
 function clipOrPad(line: string, width: number): string {
   const clean = stripAnsi(line);
-  const w = visualLen(clean);
+  const w = visualWidth(clean);
   if (w === width) return clean;
   if (w > width) {
     const arr = [...clean];
@@ -212,7 +203,7 @@ export class StatusBar {
     const frame = SPINNER_FRAMES[this.frameIdx];
     const tail = this.suffix.length > 0 ? `  ${this.suffix}` : '';
     const text = `${frame}  ${this.message}${tail}`;
-    const truncated = visualLen(text) > cols ? `${text.slice(0, cols - 1)}…` : text;
+    const truncated = visualWidth(text) > cols ? `${text.slice(0, cols - 1)}…` : text;
     const styled = this.color ? pc.cyan(truncated) : truncated;
     this.out.write(`\x1b7\x1b[${rows};1H\x1b[2K${styled}\x1b8`);
   }

--- a/apps/cli/src/ui/width.ts
+++ b/apps/cli/src/ui/width.ts
@@ -1,0 +1,42 @@
+// Visual cell width, ANSI-aware. One definition, shared by the layout/help
+// code (re-exported from ui/log) and the status bar. These used to carry two
+// different ANSI regexes that disagreed on what to strip: ui/log matched only
+// SGR colour sequences, the status bar matched every CSI sequence. Measuring a
+// styled string now strips the same set in both places.
+
+// Strip every CSI escape sequence — colour AND cursor movement — so a measured
+// string counts only the cells it actually occupies.
+// biome-ignore lint/suspicious/noControlCharactersInRegex: stripping ANSI on purpose
+const ANSI_CSI = /\x1b\[[0-9;?]*[A-Za-z]/g;
+
+export function stripAnsi(s: string): string {
+  return s.replace(ANSI_CSI, '');
+}
+
+/**
+ * Visual cell width of a string after stripping ANSI, counting basic
+ * CJK/fullwidth codepoints as 2 cells so logos and boxes align. Not a full
+ * Unicode width implementation — just enough for the characters this project
+ * uses.
+ */
+export function visualWidth(s: string): number {
+  let w = 0;
+  for (const ch of stripAnsi(s)) {
+    const cp = ch.codePointAt(0) ?? 0;
+    // Rough fullwidth ranges: CJK symbols/punct, CJK unified, fullwidth forms.
+    const fullwidth =
+      (cp >= 0x1100 && cp <= 0x115f) ||
+      (cp >= 0x2e80 && cp <= 0x303f) ||
+      (cp >= 0x3041 && cp <= 0x33ff) ||
+      (cp >= 0x3400 && cp <= 0x4dbf) ||
+      (cp >= 0x4e00 && cp <= 0x9fff) ||
+      (cp >= 0xa000 && cp <= 0xa4cf) ||
+      (cp >= 0xac00 && cp <= 0xd7a3) ||
+      (cp >= 0xf900 && cp <= 0xfaff) ||
+      (cp >= 0xfe30 && cp <= 0xfe4f) ||
+      (cp >= 0xff00 && cp <= 0xff60) ||
+      (cp >= 0xffe0 && cp <= 0xffe6);
+    w += fullwidth ? 2 : 1;
+  }
+  return w;
+}

--- a/apps/cli/src/ui/width.ts
+++ b/apps/cli/src/ui/width.ts
@@ -13,30 +13,57 @@ export function stripAnsi(s: string): string {
   return s.replace(ANSI_CSI, '');
 }
 
+// Rough fullwidth ranges: CJK symbols/punct, CJK unified, fullwidth forms.
+// Not a full Unicode width table, just enough for the characters this project
+// renders (logos, CJK package names).
+function isFullwidth(cp: number): boolean {
+  return (
+    (cp >= 0x1100 && cp <= 0x115f) ||
+    (cp >= 0x2e80 && cp <= 0x303f) ||
+    (cp >= 0x3041 && cp <= 0x33ff) ||
+    (cp >= 0x3400 && cp <= 0x4dbf) ||
+    (cp >= 0x4e00 && cp <= 0x9fff) ||
+    (cp >= 0xa000 && cp <= 0xa4cf) ||
+    (cp >= 0xac00 && cp <= 0xd7a3) ||
+    (cp >= 0xf900 && cp <= 0xfaff) ||
+    (cp >= 0xfe30 && cp <= 0xfe4f) ||
+    (cp >= 0xff00 && cp <= 0xff60) ||
+    (cp >= 0xffe0 && cp <= 0xffe6)
+  );
+}
+
 /**
- * Visual cell width of a string after stripping ANSI, counting basic
- * CJK/fullwidth codepoints as 2 cells so logos and boxes align. Not a full
- * Unicode width implementation — just enough for the characters this project
- * uses.
+ * Visual cell width of a string after stripping ANSI, counting fullwidth
+ * codepoints as 2 cells so logos and boxes align. Not a full Unicode width
+ * implementation, just enough for the characters this project uses.
  */
 export function visualWidth(s: string): number {
   let w = 0;
   for (const ch of stripAnsi(s)) {
-    const cp = ch.codePointAt(0) ?? 0;
-    // Rough fullwidth ranges: CJK symbols/punct, CJK unified, fullwidth forms.
-    const fullwidth =
-      (cp >= 0x1100 && cp <= 0x115f) ||
-      (cp >= 0x2e80 && cp <= 0x303f) ||
-      (cp >= 0x3041 && cp <= 0x33ff) ||
-      (cp >= 0x3400 && cp <= 0x4dbf) ||
-      (cp >= 0x4e00 && cp <= 0x9fff) ||
-      (cp >= 0xa000 && cp <= 0xa4cf) ||
-      (cp >= 0xac00 && cp <= 0xd7a3) ||
-      (cp >= 0xf900 && cp <= 0xfaff) ||
-      (cp >= 0xfe30 && cp <= 0xfe4f) ||
-      (cp >= 0xff00 && cp <= 0xff60) ||
-      (cp >= 0xffe0 && cp <= 0xffe6);
-    w += fullwidth ? 2 : 1;
+    w += isFullwidth(ch.codePointAt(0) ?? 0) ? 2 : 1;
   }
   return w;
+}
+
+/**
+ * Truncate `s` so its visual width is at most `maxCells`, appending `…` (one
+ * cell) when it had to cut. Fullwidth codepoints count as 2 cells, like
+ * visualWidth, so the result never renders wider than `maxCells` columns.
+ * String.slice truncates by UTF-16 code units and would overshoot on fullwidth
+ * text, leaving the line wider than intended. Assumes plain text; callers strip
+ * ANSI first.
+ */
+export function clipToWidth(s: string, maxCells: number): string {
+  if (visualWidth(s) <= maxCells) return s;
+  if (maxCells <= 1) return '…';
+  const budget = maxCells - 1; // reserve one cell for the ellipsis
+  let width = 0;
+  let out = '';
+  for (const ch of s) {
+    const w = isFullwidth(ch.codePointAt(0) ?? 0) ? 2 : 1;
+    if (width + w > budget) break;
+    out += ch;
+    width += w;
+  }
+  return `${out}…`;
 }

--- a/apps/cli/src/wizard-runner.ts
+++ b/apps/cli/src/wizard-runner.ts
@@ -20,7 +20,14 @@ import * as logui from './ui/log';
 import { renderAppleLogo } from './ui/logo';
 import { pageableAutocompleteMultiselect } from './ui/picker';
 import { getVersion } from './version';
-import { type ActionResult, type Target, type WizardDeps, pickAction, pickTarget } from './wizard';
+import {
+  type ActionDeps,
+  type ActionResult,
+  type Target,
+  type TargetDeps,
+  pickAction,
+  pickTarget,
+} from './wizard';
 
 // Cap clack's autocompleteMultiselect window to a sensible fraction of
 // the terminal height so the user can still see the prompt header and
@@ -317,7 +324,7 @@ function reportPickerFailure(what: string, unwindsTo: string, err: unknown): voi
  * is reported and unwound to the plugin picker.
  */
 export async function pickActionSafely(
-  wizardDeps: WizardDeps,
+  wizardDeps: ActionDeps,
   target: Target,
 ): Promise<ActionResult | null | typeof PICKER_FAILED> {
   try {
@@ -336,7 +343,7 @@ export async function pickActionSafely(
  * back to unwind to, so this ends the wizard — but on our terms, with the
  * cause reported and a failing exit code, rather than a raw trace.
  */
-async function pickTargetSafely(wizardDeps: WizardDeps): Promise<Target | null> {
+async function pickTargetSafely(wizardDeps: TargetDeps): Promise<Target | null> {
   try {
     return await pickTarget(wizardDeps);
   } catch (err) {
@@ -406,7 +413,6 @@ export async function runWizard(
         if (isCancel(choice) || choice === null) return null;
         return choice as Target;
       },
-      selectAction: async () => null, // unused at the target stage
       printAbout: () => printAboutScreen(deps.color),
     });
     if (!target) return; // Esc at target picker → exit wizard.
@@ -416,7 +422,6 @@ export async function runWizard(
       const result: ActionResult | null | typeof PICKER_FAILED = await pickActionSafely(
         {
           plugins: deps.registry,
-          selectTarget: async () => null, // unused at the action stage
           selectAction: async (t, opts) => {
             // Sticky inverted-pill header — printed on every prompt
             // iteration so the user always sees which category they're

--- a/apps/cli/src/wizard.ts
+++ b/apps/cli/src/wizard.ts
@@ -27,7 +27,13 @@ export type WizardActionOption =
   | 'search-add'
   | 'install';
 
-export interface WizardDeps {
+// The two picker stages take disjoint callbacks, so each has its own deps
+// interface. Splitting them means neither caller has to stub a callback the
+// other stage owns (pickTarget never touches selectAction, pickAction never
+// touches selectTarget).
+
+/** What the target picker (`pickTarget`) needs. */
+export interface TargetDeps {
   readonly plugins: readonly Plugin[];
   readonly selectTarget: (
     groups: ReadonlyArray<{
@@ -35,12 +41,20 @@ export interface WizardDeps {
       readonly items: ReadonlyArray<{ readonly label: string; readonly value: Target }>;
     }>,
   ) => Promise<Target | null>;
+  /** Renders the "About macup" screen when the Help target is picked. */
+  readonly printAbout?: () => void;
+}
+
+/** What the action picker (`pickAction`) needs: the action choice plus the
+ * per-action IO callbacks. */
+export interface ActionDeps {
+  readonly plugins: readonly Plugin[];
   readonly selectAction: (
     target: Target,
     options: ReadonlyArray<{ readonly label: string; readonly value: WizardActionOption }>,
   ) => Promise<WizardActionOption | null>;
   /**
-   * Picker for "Update selected". Receives the outdated rows; returns the
+   * Picker for "Update selectively". Receives the outdated rows; returns the
    * subset to update, null to nav back to the action prompt, or [] to also
    * nav back (treated as "nothing to do").
    */
@@ -53,12 +67,12 @@ export interface WizardDeps {
     }>,
   ) => Promise<readonly string[] | null>;
   /**
-   * Picker for "Add/Remove tracked". Returns the desired tracked set
+   * Picker for "Track/Untrack". Returns the desired tracked set
    * (any subset of installed ∪ tracked), or null to nav back.
    */
   readonly pickTrackedSet?: (target: Target) => Promise<readonly string[] | null>;
   /**
-   * "Search & add": prompt for a query, search the backend, and return the
+   * "Search & track": prompt for a query, search the backend, and return the
    * package names the user chose to track — or null to nav back. Required
    * only when the search-add action is offered, i.e. when the plugin exposes
    * `search` AND can track additions (track capability + a configKey).
@@ -66,7 +80,7 @@ export interface WizardDeps {
   readonly searchAndPick?: (target: Target) => Promise<readonly string[] | null>;
   /** Reads current tracked names for the given target. Required when sync-tracked is offered. */
   readonly currentTracked?: (target: Target) => Promise<readonly string[]>;
-  /** Fetches outdated rows for "Update selected". Required alongside pickOutdated. */
+  /** Fetches outdated rows for "Update selectively". Required alongside pickOutdated. */
   readonly fetchOutdated?: (target: Target) => Promise<
     ReadonlyArray<{
       readonly name: string;
@@ -74,9 +88,12 @@ export interface WizardDeps {
       readonly latestVersion?: string;
     }>
   >;
-  /** Renders the "About macup" screen when the Help target is picked. */
-  readonly printAbout?: () => void;
 }
+
+/** Combined bag for callers that build one deps object for both stages — the
+ * runner's wizard loop and the unit tests. pickTarget/pickAction each take
+ * only their half, so neither stubs a callback the other stage needs. */
+export type WizardDeps = TargetDeps & ActionDeps;
 
 /** Synthetic plugin id for the Help entry on the target prompt. */
 export const WIZARD_HELP_PLUGIN_ID = '__about__';
@@ -123,7 +140,7 @@ function buildGroups(plugins: readonly Plugin[]): Array<{
   return out;
 }
 
-export async function pickTarget(deps: WizardDeps): Promise<Target | null> {
+export async function pickTarget(deps: TargetDeps): Promise<Target | null> {
   const { selectTarget, plugins, printAbout } = deps;
   const groups = buildGroups(plugins);
   while (true) {
@@ -175,7 +192,7 @@ function diffTracked(
   return { adds, removes };
 }
 
-export async function pickAction(deps: WizardDeps, target: Target): Promise<ActionResult | null> {
+export async function pickAction(deps: ActionDeps, target: Target): Promise<ActionResult | null> {
   const plugin = deps.plugins.find((p) => p.manifest.id === target.pluginId);
   if (!plugin) {
     console.error(`error: plugin "${target.pluginId}" is not registered`);

--- a/apps/cli/test/unit/commands/plugins.test.ts
+++ b/apps/cli/test/unit/commands/plugins.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it } from 'vitest';
-import { buildPluginsReport, formatPluginsReport } from '../../../src/commands/plugins';
+import { describe, expect, it, vi } from 'vitest';
+import type { CliDeps } from '../../../src/cli/types';
+import { buildPluginsReport, formatPluginsReport, runPlugins } from '../../../src/commands/plugins';
 import type { Plugin, PluginCapabilities, PluginManifest } from '../../../src/plugins/types';
 
 const caps = (over: Partial<PluginCapabilities> = {}): PluginCapabilities => ({
@@ -149,5 +150,33 @@ describe('formatPluginsReport', () => {
     });
     const out = formatPluginsReport(report, { color: true });
     expect(out).toContain(ansiStart);
+  });
+});
+
+describe('runPlugins (wiring)', () => {
+  it('renders the report from injected registry, platform, and onPath', async () => {
+    const deps = {
+      registry: [
+        mkPlugin({ id: 'brew', displayName: 'Homebrew', requires: ['brew'] }),
+        mkPlugin({ id: 'npm', displayName: 'npm', requires: ['npm'] }),
+      ],
+      platform: 'darwin',
+      exec: { onPath: (b: string) => b === 'brew' },
+      color: false,
+    } as unknown as CliDeps;
+
+    const lines: string[] = [];
+    const spy = vi.spyOn(console, 'log').mockImplementation((m?: unknown) => {
+      lines.push(String(m));
+    });
+    try {
+      await runPlugins({}, deps);
+    } finally {
+      spy.mockRestore();
+    }
+    const out = lines.join('\n');
+    expect(out).toContain('plugins: 1 / 2 available');
+    expect(out).toContain('brew');
+    expect(out).toContain('missing: npm');
   });
 });

--- a/apps/cli/test/unit/commands/render-list.test.ts
+++ b/apps/cli/test/unit/commands/render-list.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+import { renderList } from '../../../src/commands/render-list';
+import type { PackageStatus } from '../../../src/plugins/types';
+
+function st(
+  name: string,
+  opts: {
+    kind?: string;
+    installed?: boolean;
+    installedVersion?: string;
+    latestVersion?: string;
+  } = {},
+): PackageStatus {
+  return {
+    ref: { kind: opts.kind ?? 'npm', name },
+    installed: opts.installed ?? true,
+    installedVersion: opts.installedVersion,
+    latestVersion: opts.latestVersion,
+    outdated: opts.latestVersion !== undefined,
+  };
+}
+
+describe('renderList', () => {
+  it('reports when a plugin has no packages', () => {
+    expect(renderList('npm', [], false)).toContain('No npm packages found.');
+  });
+
+  it('renders up-to-date and outdated packages together', () => {
+    const out = renderList(
+      'npm',
+      [
+        st('typescript', { installedVersion: '5.3.3' }),
+        st('eslint', { installedVersion: '8.0.0', latestVersion: '9.0.0' }),
+      ],
+      false,
+    );
+    expect(out).toContain('typescript');
+    expect(out).toContain('eslint');
+    expect(out).toContain('9.0.0');
+  });
+
+  it('filters to outdated only when onlyOutdated is set', () => {
+    const out = renderList(
+      'npm',
+      [
+        st('typescript', { installedVersion: '5.3.3' }),
+        st('eslint', { installedVersion: '8.0.0', latestVersion: '9.0.0' }),
+      ],
+      true,
+    );
+    expect(out).toContain('eslint');
+    expect(out).not.toContain('typescript');
+  });
+
+  it('groups by kind when a plugin reports more than one kind', () => {
+    const out = renderList(
+      'brew',
+      [
+        st('git', { kind: 'formula', installedVersion: '2.4' }),
+        st('firefox', { kind: 'cask', installedVersion: '120' }),
+      ],
+      false,
+    );
+    expect(out).toContain('FORMULAS');
+    expect(out).toContain('CASKS');
+    expect(out).toContain('git');
+    expect(out).toContain('firefox');
+  });
+
+  it('lists not-installed tracked packages', () => {
+    const out = renderList('npm', [st('ghost', { installed: false })], false);
+    expect(out).toContain('ghost');
+  });
+});

--- a/apps/cli/test/unit/ui/width.test.ts
+++ b/apps/cli/test/unit/ui/width.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { clipToWidth, stripAnsi, visualWidth } from '../../../src/ui/width';
+
+describe('visualWidth', () => {
+  it('counts ASCII as one cell each', () => {
+    expect(visualWidth('hello')).toBe(5);
+  });
+
+  it('counts fullwidth CJK as two cells each', () => {
+    expect(visualWidth('日本')).toBe(4);
+  });
+
+  it('strips ANSI before measuring', () => {
+    expect(visualWidth('\x1b[32mhi\x1b[0m')).toBe(2);
+    expect(stripAnsi('\x1b[32mhi\x1b[0m')).toBe('hi');
+  });
+});
+
+describe('clipToWidth', () => {
+  it('returns the string unchanged when it already fits', () => {
+    expect(clipToWidth('hello', 10)).toBe('hello');
+    expect(clipToWidth('hello', 5)).toBe('hello');
+  });
+
+  it('truncates ASCII to at most maxCells, ending in an ellipsis', () => {
+    const out = clipToWidth('hello world', 5);
+    expect(visualWidth(out)).toBeLessThanOrEqual(5);
+    expect(out.endsWith('…')).toBe(true);
+  });
+
+  it('never exceeds maxCells for fullwidth text', () => {
+    // Ten fullwidth chars = 20 cells, but each is a single UTF-16 code unit.
+    // A String.slice(0, cols - 1) would keep cols - 1 chars ≈ 2 * (cols - 1)
+    // cells and overshoot — the bug this guards against.
+    const wide = '日'.repeat(10);
+    for (const cols of [3, 4, 8, 15]) {
+      expect(visualWidth(clipToWidth(wide, cols))).toBeLessThanOrEqual(cols);
+    }
+  });
+
+  it('degrades to just the ellipsis at width 1', () => {
+    expect(clipToWidth('anything', 1)).toBe('…');
+  });
+});

--- a/apps/cli/test/unit/wizard.test.ts
+++ b/apps/cli/test/unit/wizard.test.ts
@@ -156,7 +156,6 @@ describe('pickTarget', () => {
         groupsSeen = groups;
         return null;
       },
-      selectAction: async () => null,
     });
     const allValues = groupsSeen.flatMap((g) => g.items.map((i) => i.value.pluginId));
     expect(allValues).not.toContain('all');
@@ -208,7 +207,6 @@ describe('pickAction — option gating', () => {
     await pickAction(
       {
         plugins: [noKeys],
-        selectTarget: async () => null,
         selectAction: async (_t, opts) => {
           offered = opts.map((o) => o.value);
           return null;
@@ -234,7 +232,6 @@ describe('pickAction — option gating', () => {
     await pickAction(
       {
         plugins: [noOutdated],
-        selectTarget: async () => null,
         selectAction: async (_t, opts) => {
           offered = opts.map((o) => o.value);
           return null;
@@ -252,7 +249,6 @@ describe('pickAction — option gating', () => {
     await pickAction(
       {
         plugins: [searchable],
-        selectTarget: async () => null,
         selectAction: async (_t, opts) => {
           offered = opts.map((o) => o.value);
           return null;
@@ -330,7 +326,6 @@ describe('pickAction — update-selected', () => {
     const result = await pickAction(
       {
         plugins: [npm],
-        selectTarget: async () => null,
         selectAction: async () => 'update-selected',
         fetchOutdated: async () => [
           { name: 'typescript', currentVersion: '1.0.0', latestVersion: '5.4.0' },
@@ -356,7 +351,6 @@ describe('pickAction — update-selected', () => {
     const result = await pickAction(
       {
         plugins: [npm],
-        selectTarget: async () => null,
         selectAction: async () => {
           actionCalls++;
           return actionCalls === 1 ? 'update-selected' : null;
@@ -377,7 +371,6 @@ describe('pickAction — update-selected', () => {
     const result = await pickAction(
       {
         plugins: [npm],
-        selectTarget: async () => null,
         selectAction: async () => {
           actionCalls++;
           return actionCalls === 1 ? 'update-selected' : null;
@@ -436,7 +429,6 @@ describe('pickAction — search-add', () => {
     const result = await pickAction(
       {
         plugins: [searchable],
-        selectTarget: async () => null,
         selectAction: async () => 'search-add',
         searchAndPick: async (t) => {
           searchedTarget = t;
@@ -460,7 +452,6 @@ describe('pickAction — search-add', () => {
       const result = await pickAction(
         {
           plugins: [searchable],
-          selectTarget: async () => null,
           selectAction: async () => {
             actionCalls++;
             return actionCalls === 1 ? 'search-add' : null;
@@ -479,7 +470,6 @@ describe('pickAction — search-add', () => {
     const result = await pickAction(
       {
         plugins: [searchable],
-        selectTarget: async () => null,
         selectAction: async () => 'search-add',
       },
       { pluginId: 'brew' },

--- a/docs/adr/0032-execrunner-interface-and-path-lookup.md
+++ b/docs/adr/0032-execrunner-interface-and-path-lookup.md
@@ -1,0 +1,23 @@
+# ADR 0032: Keep the ExecRunner interface, move the PATH lookup to a leaf
+
+> Status: accepted · Date: 2026-07-16 · Deciders: John Valai
+
+## Context
+
+An architecture review recommended narrowing `ExecRunner` (ADR 0010) from `run` / `runJson` / `onPath` down to just `run`: `runJson` has two production call sites (both in brew) yet four implementations, and `onPath` runs no subprocess. The review's sharper point was a genuine defect underneath: `exec/run.ts`, the lowest-level subprocess primitive, imported `isOnPath` from `plugins/registry.ts`, which imports every plugin. The lowest layer reached up into the highest.
+
+## Decision
+
+Fix the inversion, keep the interface. `pathTo` and `isOnPath` move to a new leaf module, `apps/cli/src/exec/on-path.ts`, whose only dependencies are node's `fs` and `path`. `exec/run.ts` imports the PATH lookup from there, so it no longer imports the registry. The registry re-exports both functions for its existing consumers (the doctor report and `buildRegistry`). `runJson` and `onPath` stay on the `ExecRunner` interface.
+
+## Alternatives
+
+- **Drop `runJson`.** It has two callers, but removing it churns four runner implementations plus six test files (the runJson unit tests and the doubles that satisfy the interface), for a small gain. Deferred: brew can move to `run` + the shared `safeParseJson` (from ADR-era plugin helpers) whenever that surface is next touched.
+- **Drop `onPath`.** Removing it forces `defaultCheck` (in `plugins/`) to import `isOnPath` directly, which reintroduces the very cycle the method was added to avoid: `defaults` to `registry` to plugins to `defaults`. Keeping `onPath` on the runner sidesteps that.
+- **Leave it.** Keeps the `exec` to `registry` inversion, so the subprocess primitive keeps transitively importing every plugin. Rejected: that is the load-bearing smell.
+
+## Consequences
+
+- `exec/run.ts` depends only on `execa`, the plugin types, and a leaf PATH utility. The lowest layer no longer pulls in the registry or the plugins behind it.
+- The interface stays one method wider than the theoretical minimum, a deliberate trade recorded here so a future review does not re-propose the narrowing without the churn and cycle context.
+- ADR 0010 stands: `ExecRunner` is still the single subprocess seam, and `execa` is still imported only by `exec/run.ts`.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -59,3 +59,4 @@ ADR-NNNN". Do not rewrite the old record. The trail is the point.
 | [0029](0029-command-nouns-are-subcommands.md) | Command nouns are subcommands, not flags | accepted |
 | [0030](0030-pin-is-a-version-ceiling.md) | A pin is a version ceiling, not an exact lock | accepted |
 | [0031](0031-track-untrack-verbs.md) | Applist verbs are track and untrack, not add and remove | accepted |
+| [0032](0032-execrunner-interface-and-path-lookup.md) | Keep the ExecRunner interface, move the PATH lookup to a leaf | accepted |


### PR DESCRIPTION
## What

Implements all 8 candidates from the architecture review (deep-module deepening pass), each as its own tested commit. Every commit keeps `pnpm lint && pnpm typecheck && pnpm test` green; the review was re-scanned against post-#70 `main` first, since the track/untrack rename had moved most of the target files.

31 files, +594/−399. 606 tests pass (2 skipped).

## Candidates → commits

| # | Candidate | Commit |
|---|---|---|
| 3 | One command registry — dispatch/help/completions/docs project from `src/cli/commands.ts` | `51309a1` |
| 8 | One colour convention — shared `ui/width.ts` + `ui/color.ts` painter; no raw `\x1b[`; dead `versionBlock` gone | `0eeb8c3` |
| 2 | Applist-key leak — doctor reads the applist by generic key path, not an exhaustive switch | `d1f5916` |
| 5 | Shipped-wiring seams — `runPlugins` driven from `deps` (+ `CliDeps.platform`); `outdated` uses `deps.signal`; tests for `runPlugins`/`renderList` | `22bfc39` |
| 7 | Wizard seam — `WizardDeps` split into `TargetDeps`/`ActionDeps`; the two stub callbacks gone | `a0369c6` |
| 1 | Host loop — shared `mutateRefs`/`filterOutdated`/`safeParseJson`; **11 dropped `ctx.signal` fixed** | `889b3ab` |
| 4 | from-manifest seam — `commitMutation` replaces the 6-copy mutate→save→report protocol | `97c1d25` |
| 6 | Exec inversion — PATH lookup moved to leaf `src/exec/on-path.ts`; `run.ts` no longer imports the registry (ADR 0032) | `2898dec` |

## Shipped bugs fixed along the way

- **`macup --help` omitted `doctor` and `completions`** — both real, dispatched commands. The one-registry projection (cand. 3) surfaces every command.
- **Ctrl-C cancelled some commands and not others** — 11 read/mutate call sites dropped `ctx.signal` (including a `user-action` mutation in xcode). `mutateRefs` and the explicit read fixes (cand. 1) close it.
- **`macup outdated`'s spinner path** built a fresh `AbortController`, so its plugin probes ignored Ctrl-C while the `--json` path honoured it (cand. 5).

## New ADR

**ADR 0032** records the one deliberate deviation from the review: candidate 6 recommended narrowing `ExecRunner` to just `run`. I fixed the load-bearing defect (the `exec → registry` dependency inversion) but kept `runJson`/`onPath` on the interface — dropping `runJson` churns 4 impls + 6 test files for 2 callers, and dropping `onPath` reintroduces a `defaults → registry` cycle. ADR 0010 still stands.

## Deliberately bounded (called out for review)

A few candidates were scoped to the clean, low-risk core, with the deeper move noted rather than forced:

- **Cand. 2:** removed the doctor's exhaustive switch; kept the `ApplistKey` schema enum as the declared chokepoint (fully deriving it from manifests hits a `schema → registry → plugins → schema` cycle and drops static validation).
- **Cand. 1:** shared the mutate loop + JSON parse and fixed signals; the deeper "plugins return argv, host executes" contract inversion is a follow-up. `system`/`xcode` keep their divergent mutate paths; `mas` is unchanged.
- **Cand. 4:** extracted the mutate→save→report protocol; the per-ref install/update loop and tracked-set gather (each duplicated twice) are a follow-up.
- **Cand. 6:** interface narrowing deferred per ADR 0032.

## Verification

`pnpm lint && pnpm typecheck && pnpm test` green after every commit; `pnpm adr:check` green (32 ADRs, index in sync). Built on an isolated worktree off merged `main`.
